### PR TITLE
feat(networking): Add Caddy reverse proxy configuration

### DIFF
--- a/hosts/cloudy/configuration.nix
+++ b/hosts/cloudy/configuration.nix
@@ -1,4 +1,4 @@
-{inputs, ...}: {
+{inputs, pkgs, ...}: {
   imports = [
     inputs.disko.nixosModules.disko
     inputs.opnix.nixosModules.default
@@ -7,6 +7,7 @@
     ../../modules/nixos
     ../../modules/home-manager
   ];
+
   services.onepassword-secrets = {
     enable = true;
     tokenFile = "/etc/opnix-token";
@@ -21,6 +22,11 @@
     attic.server.enable = true;
     jellyfin.server.enable = true;
     minio.server.enable = true;
+
+    caddy = {
+      enable = true;
+      domain = "rgbr.ink";
+    };
   };
 
   # TODO: Make configurable module

--- a/modules/common/host-info.nix
+++ b/modules/common/host-info.nix
@@ -30,6 +30,15 @@
       };
     };
     host = {
+      caddy = {
+        enable = mkEnableOption "Enable Caddy reverse proxy";
+        domain = mkOption {
+          type = types.str;
+          default = "rgbr.ink";
+          description = "The primary domain name";
+        };
+      };
+
       gitSigningKey = mkOption {
         type = types.str;
         default = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP+4LZpJ9+QmvjLKMzmHX1aUdsnoOlrrcTjwKhcwnCN1";
@@ -99,6 +108,10 @@
   config = {
     host = {
       admin.name = lib.mkDefault "ryan";
+
+      caddy = {
+        enable = lib.mkDefault false;
+      };
 
       desktop = {
         enable = lib.mkDefault true;

--- a/modules/nixos/caddy.nix
+++ b/modules/nixos/caddy.nix
@@ -1,0 +1,18 @@
+{ config, lib, ... }: {
+  config = lib.mkIf config.host.caddy.enable {
+    services.caddy = {
+      enable = true;
+
+      virtualHosts = {
+        "${config.host.caddy.domain}" = {
+          extraConfig = ''
+            tls /etc/ssl/certs/cloudflare-cert.pem /etc/ssl/private/cloudflare-key.pem
+            respond "Hello, world!"
+          '';
+        };
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = [ 443 ];
+  };
+}

--- a/modules/nixos/caddy.nix
+++ b/modules/nixos/caddy.nix
@@ -5,6 +5,7 @@
 
       virtualHosts = {
         "${config.host.caddy.domain}" = {
+          # TODO: provide files via opnix
           extraConfig = ''
             tls /etc/ssl/certs/cloudflare-cert.pem /etc/ssl/private/cloudflare-key.pem
             respond "Hello, world!"

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -8,6 +8,7 @@
     ./attic.nix
     ./audio.nix
     ./boot.nix
+    ./caddy.nix
     ./display-manager.nix
     ./docker.nix
     ./environment.nix


### PR DESCRIPTION
Adds a new Caddy reverse proxy configuration to the `host-info.nix` file.
The changes include:

- Adds a new `caddy` section with an `enable` option to toggle the Caddy
  service.
- Adds a new `domain` option to configure the primary domain name.

These changes are necessary to enable and configure the Caddy reverse proxy
for the host.