### PR TITLE
feat(home-manager): add Zed editor configuration

### DIFF
--- a/modules/home-manager/profiles/personal.nix
+++ b/modules/home-manager/profiles/personal.nix
@@ -8,6 +8,7 @@
   currentUsername = config.home.username;
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
+  zedConfig = import ../zed-config.nix {inherit lib pkgs;};
 in {
   imports = [
     opnix.homeManagerModules.default
@@ -73,6 +74,7 @@ in {
     ffmpeg
     yt-dlp
   ];
+<<<<<<< ours
 
   # Personal 1Password SSH Agent Configuration
   xdg.configFile."1Password/ssh/agent.toml".text = ''
@@ -86,4 +88,23 @@ in {
     vault = "Private"
     account = "my.1password.com"
   '';
+
+  # Personal Zed Editor Configuration
+  xdg.configFile."zed/settings.json".source = zedConfig.zed.personal;
+||||||| ancestor
+=======
+
+  # Personal 1Password SSH Agent Configuration
+  xdg.configFile."1Password/ssh/agent.toml".text = ''
+    [[ssh-keys]]
+    item = "Personal Auth Key"
+    vault = "Private"
+    account = "my.1password.com"
+
+    [[ssh-keys]]
+    item = "Personal Signing Key"
+    vault = "Private"
+    account = "my.1password.com"
+  '';
+>>>>>>> theirs
 }

--- a/modules/home-manager/profiles/personal.nix
+++ b/modules/home-manager/profiles/personal.nix
@@ -74,9 +74,7 @@ in {
     ffmpeg
     yt-dlp
   ];
-<<<<<<< ours
 
-  # Personal 1Password SSH Agent Configuration
   xdg.configFile."1Password/ssh/agent.toml".text = ''
     [[ssh-keys]]
     item = "Personal Auth Key"
@@ -89,22 +87,5 @@ in {
     account = "my.1password.com"
   '';
 
-  # Personal Zed Editor Configuration
   xdg.configFile."zed/settings.json".source = zedConfig.zed.personal;
-||||||| ancestor
-=======
-
-  # Personal 1Password SSH Agent Configuration
-  xdg.configFile."1Password/ssh/agent.toml".text = ''
-    [[ssh-keys]]
-    item = "Personal Auth Key"
-    vault = "Private"
-    account = "my.1password.com"
-
-    [[ssh-keys]]
-    item = "Personal Signing Key"
-    vault = "Private"
-    account = "my.1password.com"
-  '';
->>>>>>> theirs
 }

--- a/modules/home-manager/profiles/work.nix
+++ b/modules/home-manager/profiles/work.nix
@@ -7,6 +7,7 @@
 }: let
   currentUsername = config.home.username;
   isDarwin = pkgs.stdenv.isDarwin;
+  zedConfig = import ../zed-config.nix {inherit lib pkgs;};
 in {
   imports = [
     opnix.homeManagerModules.default
@@ -55,6 +56,7 @@ in {
   ];
 
   programs.ssh.enable = lib.mkDefault false;
+<<<<<<< ours
 
   # Work 1Password SSH Agent Configuration
   xdg.configFile."1Password/ssh/agent.toml".text = ''
@@ -68,4 +70,23 @@ in {
     vault = "Employee"
     account = "teamodyssey.1password.com"
   '';
+
+  # Work Zed Editor Configuration
+  xdg.configFile."zed/settings.json".source = zedConfig.zed.work;
+||||||| ancestor
+=======
+
+  # Work 1Password SSH Agent Configuration
+  xdg.configFile."1Password/ssh/agent.toml".text = ''
+    [[ssh-keys]]
+    item = "Odyssey Auth Key"
+    vault = "Employee"
+    account = "teamodyssey.1password.com"
+
+    [[ssh-keys]]
+    item = "Odyssey Signing Key"
+    vault = "Employee"
+    account = "teamodyssey.1password.com"
+  '';
+>>>>>>> theirs
 }

--- a/modules/home-manager/profiles/work.nix
+++ b/modules/home-manager/profiles/work.nix
@@ -56,9 +56,7 @@ in {
   ];
 
   programs.ssh.enable = lib.mkDefault false;
-<<<<<<< ours
 
-  # Work 1Password SSH Agent Configuration
   xdg.configFile."1Password/ssh/agent.toml".text = ''
     [[ssh-keys]]
     item = "Odyssey Auth Key"
@@ -71,22 +69,5 @@ in {
     account = "teamodyssey.1password.com"
   '';
 
-  # Work Zed Editor Configuration
   xdg.configFile."zed/settings.json".source = zedConfig.zed.work;
-||||||| ancestor
-=======
-
-  # Work 1Password SSH Agent Configuration
-  xdg.configFile."1Password/ssh/agent.toml".text = ''
-    [[ssh-keys]]
-    item = "Odyssey Auth Key"
-    vault = "Employee"
-    account = "teamodyssey.1password.com"
-
-    [[ssh-keys]]
-    item = "Odyssey Signing Key"
-    vault = "Employee"
-    account = "teamodyssey.1password.com"
-  '';
->>>>>>> theirs
 }

--- a/modules/home-manager/zed-config.nix
+++ b/modules/home-manager/zed-config.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  pkgs,
+  ...
+}: let
+  jsonFormat = pkgs.formats.json {};
+  # Default Zed configuration that both profiles share
+  baseZedConfig = {
+    icon_theme = "Zed (Default)";
+    gutter = {
+      line_numbers = true;
+    };
+    load_direnv = "direct";
+    terminal = {
+      shell = {
+        program = "nu";
+      };
+    };
+    agent = {
+      default_profile = "write";
+      always_allow_tool_actions = false;
+      default_model = {
+        provider = "zed.dev";
+        model = "claude-sonnet-4";
+      };
+      version = "2";
+    };
+    features = {
+      edit_prediction_provider = "zed";
+    };
+    vim_mode = true;
+    base_keymap = "JetBrains";
+    ui_font_size = 14;
+    buffer_font_size = 12;
+    theme = {
+      mode = "system";
+      light = "Ayu Light";
+      dark = "One Dark";
+    };
+    languages = {
+      Nix = {
+        formatter = {
+          external = {
+            command = "alejandra";
+          };
+        };
+      };
+    };
+  };
+
+  # Context server definitions
+  contextServers = {
+    linear = {
+      command = {
+        path = "pnpm";
+        args = ["dlx" "mcp-remote" "https://mcp.linear.app/sse"];
+        env = {};
+      };
+      settings = {};
+    };
+
+    figma = {
+      command = {
+        path = "pnpm";
+        args = ["dlx" "mcp-remote" "http://127.0.0.1:3845/sse"];
+        env = null;
+      };
+      settings = {};
+    };
+
+    asana = {
+      command = {
+        path = "pnpm";
+        args = ["dlx" "mcp-remote" "https://mcp.asana.com/sse"];
+        env = {};
+      };
+      settings = {};
+    };
+  };
+
+  # Function to create Zed config with specific context servers
+  mkZedConfig = servers: let
+    config =
+      baseZedConfig
+      // {
+        context_servers = lib.genAttrs servers (name: contextServers.${name});
+      };
+  in
+    jsonFormat.generate "zed-settings.json" config;
+in {
+  # Export the configuration functions
+  zed = {
+    inherit mkZedConfig contextServers baseZedConfig;
+
+    # Pre-configured profiles
+    personal = mkZedConfig ["linear" "figma"];
+    work = mkZedConfig ["linear" "asana" "figma"];
+  };
+}


### PR DESCRIPTION
This commit adds Zed editor configuration for both personal and work profiles.

The changes include:

- Add a new `zed-config.nix` file that defines the base Zed configuration and pre-configured profiles for personal and work use cases.
- Update the `personal.nix` and `work.nix` files to include the Zed configuration from the new `zed-config.nix` file.
- Add support for configuring the Zed editor's context servers, including Linear, Figma, and Asana.
- Ensure the Zed configuration is properly formatted and follows the recommended settings.

These changes allow for a consistent and customized Zed editor setup across both personal and work environments, improving developer productivity and experience.