### PR TITLE
feat(darwin): add fantastical and figma to common casks

### DIFF
--- a/modules/darwin/app-profiles.nix
+++ b/modules/darwin/app-profiles.nix
@@ -65,6 +65,8 @@
   commonApps = {
     casks = [
       "1password"
+      "fantastical"
+      "figma"
       "ghostty"
       "hammerspoon"
       "keymapp"


### PR DESCRIPTION
Include fantastical and figma in the commonApps casks list to
ensure these applications are installed by default on Darwin
systems. This update improves the default app set for better
productivity and design workflows.