### PR TITLE
feat(home-manager): add withodyssey context server to Zed config

### DIFF
--- a/modules/home-manager/zed-config.nix
+++ b/modules/home-manager/zed-config.nix
@@ -85,6 +85,15 @@
       };
       settings = {};
     };
+
+    withodyssey = {
+      command = {
+        path = "nix";
+        args = ["shell" "nixpkgs#pnpm" "-c" "pnpm" "dlx" "@modelcontextprotocol/server-filesystem" "/Users/Work/Workspace/withodyssey"];
+        env = {};
+      };
+      settings = {};
+    };
   };
 
   # Function to create Zed config with specific context servers
@@ -103,6 +112,6 @@ in {
 
     # Pre-configured profiles
     personal = mkZedConfig ["linear" "nixos"];
-    work = mkZedConfig ["linear" "asana" "figma" "nixos"];
+    work = mkZedConfig ["linear" "asana" "figma" "nixos" "withodyssey"];
   };
 }


### PR DESCRIPTION
Introduce a new withodyssey context server using pnpm to run the
@modelcontextprotocol/server-filesystem package. Update the work profile
to include withodyssey, enabling seamless integration with the
WithOdyssey development environment. This change improves developer
workflow by adding support for the WithOdyssey context in Zed.