### PR TITLE
refactor(home-manager): remove withodyssey context from Zed config

### DIFF
--- a/modules/home-manager/zed-config.nix
+++ b/modules/home-manager/zed-config.nix
@@ -85,15 +85,6 @@
       };
       settings = {};
     };
-
-    withodyssey = {
-      command = {
-        path = "nix";
-        args = ["shell" "nixpkgs#pnpm" "-c" "pnpm" "dlx" "@modelcontextprotocol/server-filesystem" "/Users/Work/Workspace/withodyssey"];
-        env = {};
-      };
-      settings = {};
-    };
   };
 
   # Function to create Zed config with specific context servers
@@ -112,6 +103,6 @@ in {
 
     # Pre-configured profiles
     personal = mkZedConfig ["linear" "nixos"];
-    work = mkZedConfig ["linear" "asana" "figma" "nixos" "withodyssey"];
+    work = mkZedConfig ["linear" "asana" "figma" "nixos"];
   };
 }


### PR DESCRIPTION
Remove the withodyssey command configuration and exclude it from the
work profile. This cleans up unused or deprecated context server
settings, simplifying the configuration and reducing potential
maintenance overhead.