### PR TITLE
chore: update opnix input to v0.7.0 and refresh lockfile

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -127,11 +127,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751146119,
-        "narHash": "sha256-gvjG95TCnUVJkvQvLMlnC4NqiqFyBdJk3o8/RwuHeaU=",
+        "lastModified": 1751238753,
+        "narHash": "sha256-hJUPWfz/h+QgXKaKovPwFAdNBnALsvVMggAPgBB+Qvw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "76d0c31fce2aa0c71409de953e2f9113acd5b656",
+        "rev": "cab8104e9236fab1eb9a702165454ffed353c20f",
         "type": "github"
       },
       "original": {
@@ -267,11 +267,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1751234936,
-        "narHash": "sha256-huoqAwabCvIrHLP/Nvbm3jEMdieBYL6MnbUDSX/WB8M=",
+        "lastModified": 1751238680,
+        "narHash": "sha256-mvpixFmTWS2mGyPzd1yhkoEpTESKvb2k3Z+DHv6GXOo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "97386f9f121dec017b8a5251c2a8adbdf6c3daad",
+        "rev": "34ff2f979ea7d8f161e7403a5244271ed3e342d0",
         "type": "github"
       },
       "original": {
@@ -289,14 +289,18 @@
         ]
       },
       "locked": {
-        "lastModified": 1751236211,
-        "narHash": "sha256-8rgYEC7mQILBe934bpZEopNE7WVWbwU+NZgHzR/7Z9g=",
-        "path": "/Users/ryan/Workspace/brizbuzz/opnix",
-        "type": "path"
+        "lastModified": 1751239333,
+        "narHash": "sha256-JOjMew4/0hSzSdc5z8VStindghde2dhiZ0/NUrpnOzg=",
+        "owner": "brizzbuzz",
+        "repo": "opnix",
+        "rev": "ae08d9b0545edf6a6be43cd57fcd8d4191bc823a",
+        "type": "github"
       },
       "original": {
-        "path": "/Users/ryan/Workspace/brizbuzz/opnix",
-        "type": "path"
+        "owner": "brizzbuzz",
+        "ref": "v0.7.0",
+        "repo": "opnix",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -56,8 +56,7 @@
     };
 
     opnix = {
-      # url = "github:brizzbuzz/opnix/v0.4.0";
-      url = "path:/Users/ryan/Workspace/brizbuzz/opnix";
+      url = "github:brizzbuzz/opnix/v0.7.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
Update opnix input from a local path to the official v0.7.0 GitHub
release. Refresh flake.lock to reflect updated revisions and hashes
for opnix, nixpkgs, and home-manager inputs. This ensures dependencies
are consistent and up to date.