### PR TITLE
feat(nushell): add AAX file check and user guidance

### DIFF
--- a/modules/home-manager/nushell.nix
+++ b/modules/home-manager/nushell.nix
@@ -80,6 +80,22 @@ in {
           book: string,
           series?: string
       ] {
+          # Check if file is AAX format (DRM-protected Audible format)
+          let file_extension = ($local_file | path parse | get extension | str downcase)
+          if $file_extension == "aax" {
+              print "🚫 Error: AAX files are not supported!"
+              print ""
+              print "AAX files are DRM-protected Audible audiobooks that cannot be played"
+              print "on open-source media servers like AudioBookShelf."
+              print ""
+              print "To use this audiobook, you need to:"
+              print "1. Convert AAX to M4B using tools like:"
+              print "   - AAXtoMP3: https://github.com/KrumpetPirate/AAXtoMP3"
+              print "   - audible-cli: https://github.com/mkb79/audible-cli"
+              print "2. Then upload the converted M4B file instead"
+              return null
+          }
+
           let temp_file = "~/temp_audiobook.m4b"
 
           # Build the remote directory path


### PR DESCRIPTION
Detect AAX (Audible DRM) files early in the nushell audiobook
importer and abort processing with a clear user-facing message when
encountered.

- Add file extension detection and case-insensitive check for "aax".
- Print explanatory errors describing DRM limitation and why AAX
  cannot be used with open-source media servers.
- Provide actionable steps to convert AAX to M4B and links to common
  conversion tools (AAXtoMP3, audible-cli).
- Return null to skip further processing of unsupported files.

This prevents attempting to process DRM-protected audiobooks and
gives users clear guidance on how to proceed.