### PR TITLE
feat(shell): add nrr function for rebuilds

### DIFF
--- a/modules/home-manager/nushell.nix
+++ b/modules/home-manager/nushell.nix
@@ -164,9 +164,18 @@ in {
     extraConfig = ''
       # Aliases
       alias nr = ${rebuildCommand}
-      alias nrr = ${rebuildRemoteCommand}
       alias rd = repo dump
       alias zj = zellij
+
+      # Remote rebuild function - builds remote hosts if no host specified
+      def nrr [host?: string] {
+        if ($host == null) {
+          print "No host specified, building remote hosts (ganymede, callisto)..."
+          ^colmena apply --impure --on ganymede,callisto
+        } else {
+          ^${rebuildRemoteCommand} $host
+        }
+      }
     '';
 
     envFile.text = ''


### PR DESCRIPTION
a nushell function nrr wraps the existing remote
build command. When called without an argument, nrr prints a
message and invokes colmena apply on a predefined set of remote
hosts (ganymede, callisto). When given a host name it delegates to
the original rebuildRemoteCommand with the provided host.

This restores the previous alias for nrr as a function and adds
convenience behavior to trigger multi-host rebuilds when no host
is specified. It improves ergonomics for common remote workflows.