### PR TITLE
feat(immich): disable ML and adjust media settings

### DIFF
--- a/modules/nixos/immich.nix
+++ b/modules/nixos/immich.nix
@@ -17,6 +17,23 @@
         enableVectors = false;
       };
       mediaLocation = "/data/immich";
+      # Disable machine learning to avoid resource-intensive video processing
+      machine-learning = {
+        enable = false;
+      };
+      # Configure settings to optimize for large file uploads and disable ML features
+      settings = {
+        job = {
+          smartSearch.enabled = false;
+          faceDetection.enabled = false;
+          facialRecognition.enabled = false;
+          # Keep thumbnail generation enabled for videos
+          thumbnailGeneration.enabled = true;
+          videoConversion.enabled = true;
+        };
+        # Disable new version checking for privacy
+        newVersionCheck.enabled = false;
+      };
     };
 
     # Create media storage directories on the dedicated media drive


### PR DESCRIPTION
Disable Immich machine-learning features to avoid resource-
intensive video processing and reduce CPU/GPU usage on the host.
Add machine-learning = { enable = false; } and turn off smart
search, faceDetection, and facialRecognition jobs. Keep thumbnail
generation and video conversion enabled to preserve basic video
processing and user experience. Also disable new version checks for
privacy and set mediaLocation to /data/immich as the dedicated media
storage.