### PR TITLE
feat(config): enable system-wide increased resource limits

### DIFF
--- a/hosts/ganymede/configuration.nix
+++ b/hosts/ganymede/configuration.nix
@@ -60,6 +60,13 @@
     processes = 65536; # 64K processes
   };
 
+  # Enable increased system limits for heavy service workloads
+  system-limits = {
+    enable = true;
+    fileDescriptors = 131072; # 128K file descriptors
+    processes = 65536; # 64K processes
+  };
+
   # qBittorrent configuration (traffic routed via UniFi VPN policies)
   services.qbittorrent = {
     enable = true;


### PR DESCRIPTION
Add a system-limits block toanymede's NOS configuration to
raise file descriptor and process limits for heavy service workloads.

- Introduce system-limits with enable=true.
- Set fileDescriptors to 131072 (128K) and processes to 65536 (64K).
- Annotate purpose to clarify these are for heavy services.

This ensures services like qBittorrent and other demanding daemons
have sufficient file descriptor and process quotas under high load.