### PR TITLE
fix(config): remove duplicate systemimits block

### DIFF
--- a/hosts/ganymede/configuration.nix
+++ b/hosts/ganymede/configuration.nix
@@ -60,13 +60,6 @@
     processes = 65536; # 64K processes
   };
 
-  # Enable increased system limits for heavy service workloads
-  system-limits = {
-    enable = true;
-    fileDescriptors = 131072; # 128K file descriptors
-    processes = 65536; # 64K processes
-  };
-
   # qBittorrent configuration (traffic routed via UniFi VPN policies)
   services.qbittorrent = {
     enable = true;


### PR DESCRIPTION
Remove a redundant system-limits configuration that duplicated the
existing ulimit settings. The code previously declared system-limits
(enable, fileDescriptors and processes) in addition to the already set
ulimit-style entries, causing duplication and potential confusion
during configuration management. This change deletes the extra block to
keep limits defined in a single place and simplify host configuration.