### PR TITLE
fix: add reusable per-user Docker access on NixOS

### DIFF
--- a/hosts/ganymede/configuration.nix
+++ b/hosts/ganymede/configuration.nix
@@ -92,6 +92,7 @@ in {
         name = "odyssey";
         profile = "company";
         isPrimary = false;
+        containerRuntime.docker.enable = true;
       };
     };
     profiles = {

--- a/modules/common/host-info.nix
+++ b/modules/common/host-info.nix
@@ -56,6 +56,9 @@
               default = false;
               description = "Whether this is the primary system user";
             };
+            containerRuntime = {
+              docker.enable = mkEnableOption "Enable Docker access for this user";
+            };
             git = {
               name = mkOption {
                 type = types.nullOr types.str;
@@ -149,6 +152,7 @@
           name = "ryan";
           profile = "personal";
           isPrimary = true;
+          containerRuntime.docker.enable = false;
         };
       };
 

--- a/modules/common/users/accounts.nix
+++ b/modules/common/users/accounts.nix
@@ -15,7 +15,8 @@
     shell = pkgs.nushell;
     extraGroups =
       ["wheel" "networkmanager"]
-      ++ lib.optionals (userConfig.profile == "personal") ["docker" "audio" "video"];
+      ++ lib.optionals userConfig.containerRuntime.docker.enable ["docker"]
+      ++ lib.optionals (userConfig.profile == "personal") ["audio" "video"];
     openssh.authorizedKeys.keys = [
       # Personal SSH key
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP+4LZpJ9+QmvjLKMzmHX1aUdsnoOlrrcTjwKhcwnCN1"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- add a reusable `host.users.<name>.containerRuntime.docker.enable` option for per-user Docker access
- wire Linux account group assignment to that option instead of inferring Docker access from the personal profile
- enable Docker access for the `odyssey` user on `ganymede`

## Validation
- `nix eval .#nixosConfigurations.ganymede.config.users.users.odyssey.extraGroups --json`
- `nix build .#nixosConfigurations.ganymede.config.system.build.toplevel --no-link`

## Deployment Notes
- Rebuild `ganymede` and re-login as `odyssey` for new group membership to take effect.
EOF
)