### PR TITLE
fix: move qbittorrent web ui off 8080

### DIFF
--- a/hosts/callisto/configuration.nix
+++ b/hosts/callisto/configuration.nix
@@ -74,7 +74,7 @@
     torrents = {
       enable = true;
       subdomain = "torrents";
-      target = "${backendIp}:8080";
+      target = "${backendIp}:18080";
       logLevel = "INFO";
     };
     opencodeRyan = {
@@ -233,7 +233,7 @@ in {
         # torrents = {
         #   enable = true;
         #   subdomain = "torrents";
-        #   target = "${backendHost}:8080";
+        #   target = "${backendHost}:18080";
         #   logLevel = "INFO";
         # };
         blocky = {

--- a/hosts/ganymede/configuration.nix
+++ b/hosts/ganymede/configuration.nix
@@ -116,6 +116,7 @@ in {
   services.torrents = {
     enable = true;
     qbittorrent = {
+      webuiPort = 18080;
       webuiUsernameSecretRef = "op://Homelab/Bittorrent Admin Password/username";
       webuiPasswordSecretRef = "op://Homelab/Bittorrent Admin Password/password";
       savePath = "/data/torrents/complete";


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- move qBittorrent's WebUI on `ganymede` from the shared `8080` default to host-specific port `18080`
- update `callisto`'s internal torrents reverse proxy target to the new backend port
- keep the commented public proxy example aligned with the live configuration

## Validation
- `nix develop -c nix flake check --show-trace`
EOF
)