### PR TITLE
fix: align Docker firewall backend with nftables

### DIFF
--- a/modules/nixos/docker.nix
+++ b/modules/nixos/docker.nix
@@ -1,3 +1,16 @@
-{
-  virtualisation.docker.enable = true;
+{pkgs, ...}: {
+  virtualisation.docker = {
+    enable = true;
+    daemon.settings = {
+      "firewall-backend" = "nftables";
+    };
+  };
+
+  # Docker 29's nftables backend shells out to `nft`.
+  systemd.services.docker.path = [pkgs.nftables];
+
+  boot.kernel.sysctl = {
+    "net.ipv4.ip_forward" = 1;
+    "net.ipv6.conf.all.forwarding" = 1;
+  };
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- configure the shared NixOS Docker module to use Docker 29's nftables firewall backend
- add `nftables` to the `docker.service` runtime path so dockerd can manage nft rules
- declare host forwarding sysctls needed for Docker bridge networking on nftables-backed hosts

## Validation
- `nix eval .#nixosConfigurations.ganymede.config.virtualisation.docker.daemon.settings --json`
- `nix eval .#nixosConfigurations.ganymede.config.systemd.services.docker.path --json`
- `nix build .#nixosConfigurations.ganymede.config.system.build.toplevel --no-link`

## Deployment Notes
- Rebuild the affected NixOS hosts so `dockerd` restarts with the nftables backend.
- Retest compose stacks that create bridge networks or publish ports on `ganymede`.
EOF
)