### PR TITLE
fix: move clickhouse tcp port off 9000

### DIFF
--- a/hosts/ganymede/configuration.nix
+++ b/hosts/ganymede/configuration.nix
@@ -228,6 +228,7 @@ in {
   services.clickhouse = {
     enable = true;
     openFirewall = true;
+    tcpPort = 19000;
     passwordSha256SecretRef = "op://Homelab/Clickhouse Admin/password_sha_256";
   };
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- move ClickHouse's native TCP listener on `ganymede` from the default `9000` to `19000`
- leave the HTTP listener and `callisto` reverse proxy unchanged because they use `8123`
- free up `9000` for local development work without changing the shared module default

## Validation
- `nix develop -c nix flake check --show-trace`
EOF
)