### PR TITLE
fix: start opencode after opnix secrets

### DIFF
--- a/modules/nixos/opencode.nix
+++ b/modules/nixos/opencode.nix
@@ -309,7 +309,10 @@
     };
     service = lib.nameValuePair serviceName {
       description = "OpenCode web service for ${name}";
-      wantedBy = ["multi-user.target"];
+      wantedBy = [
+        "multi-user.target"
+        "opnix-secrets.service"
+      ];
       after = [
         "network-online.target"
         "opnix-secrets.service"


### PR DESCRIPTION
## Summary
- start OpenCode services from `opnix-secrets.service` as well as `multi-user.target`
- recover from boot ordering where OpenCode misses startup before secrets are available
- preserve existing steady-state behavior while preventing post-reboot dead services on ganymede