### PR TITLE
feat(frame): redesign the desktop shell around a persistent sidebar

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.4.0"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.0.tgz",
+      "integrity": "sha512-VFIff6LHp/RVaJdrK3EQ1ijx0K1tV5i1DY5YJ+pRqwC6trunPHbvqSN0GHSTZX39RdnSc+XuzCTZQCy1W2qNOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.4.0",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.97",
+        "@opentui/solid": ">=0.1.97"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.0.tgz",
+      "integrity": "sha512-mfa3MzhqNM+Az4bgPDDXL3NdG+aYOHClXmT6/4qLxf2ulyfPpMNHqb9Dfmo4D8UfmrDsPuJHmbune73/nUQnuw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/.opencode/skills/linux-ricing-bigbang/SKILL.md
+++ b/.opencode/skills/linux-ricing-bigbang/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: linux-ricing-bigbang
+description: Iterate on this repo's Linux desktop environment with a disciplined stage, rebuild, screenshot, and refine workflow.
+---
+
+Use this skill when changing the user-facing Linux desktop experience in this repository.
+
+## Repo context
+
+- This repo contains the user's declarative desktop environment, not just isolated shell widgets.
+- Desktop-facing work may span Hyprland config, Quickshell QML, user scripts, launchers, notifications, wallpaper behavior, fonts, terminal integration, and related user config under `modules/common/users/config-files/`.
+- The desktop is delivered through Nix, so the real source of truth is the deployed system state after rebuild.
+
+## Read first when relevant
+
+- `AGENTS.md`
+- `modules/common/users/config-files/configs/hyprland.nix`
+- `modules/common/users/config-files/files/hypr/`
+- `modules/common/users/config-files/files/quickshell/`
+- any directly affected scripts, themes, fonts, or launcher config files
+
+## Scope of this skill
+
+Use it for work such as:
+
+- Hyprland layout and behavior changes
+- Quickshell bar, sidebar, popup, and widget refinement
+- notification, launcher, screenshot, and clipboard tooling
+- desktop interaction polish, theming, spacing, and visual hierarchy
+- ricing workflow improvements that affect how changes are validated locally
+
+## Core workflow
+
+1. Review the current desktop-related config before changing anything. Do not assume the problem is isolated to one file or subsystem.
+2. Make the smallest coherent change that improves the desktop experience.
+3. Ensure any new or modified relevant files are staged in git before rebuilding when the workflow depends on Nix seeing tracked files.
+4. Only run a rebuild if the user has explicitly granted permission in the current conversation.
+5. Rebuild locally with `nix develop -c colmena apply-local --impure --sudo`.
+6. After the rebuild completes, capture a fresh screenshot with `grim /tmp/quickshell-current.png` or another clearly named file.
+7. Judge the live rendered result from the screenshot rather than reasoning only from source.
+8. Iterate: adjust code, ensure files are staged if needed, rebuild again with permission, capture a new screenshot, and refine until the result is clearly better.
+
+## Permission rule
+
+- Rebuilds are not implicit. Even when this skill recommends the rebuild-and-screenshot loop, only run the rebuild command after the user has explicitly allowed it.
+- If permission has not been granted, stop after code changes and explain that live validation requires rebuild permission.
+
+## Validation guidance
+
+- Treat screenshots as a required validation step for visual changes.
+- When something looks wrong, confirm with a fresh screenshot before assuming the source of the problem.
+- If a reload or deploy appears to fail, check `quickshell log --tail <n>` or the relevant runtime logs before guessing.
+- If new files are added and the deployed result does not reflect them, check whether git staging/tracking is required for Nix to include them.
+
+## Design guidance for this repo
+
+- Preserve the user's aesthetic and workflow preferences instead of imposing generic desktop UI patterns.
+- Favor clearer hierarchy, cleaner spacing, and fewer competing surfaces.
+- Avoid duplicated controls across multiple shell surfaces unless duplication is clearly intentional.
+- Prefer changes that improve the day-to-day interaction loop, not just isolated visual flourishes.
+
+## Anti-patterns
+
+- Do not treat the desktop as Quickshell-only when the issue may involve Hyprland, scripts, or deployment wiring.
+- Do not stop at source edits for visual work without validating the live desktop.
+- Do not rebuild without explicit user permission.
+- Do not forget that tracked/staged file state can affect whether Nix sees newly added config files.

--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1775429023,
-        "narHash": "sha256-6iRePAI5ZEJk9wv/NH4IT+TnAT45oEtavGEdi2wydJ8=",
+        "lastModified": 1776047641,
+        "narHash": "sha256-EiBjUHaP8LL/JLOCHJ8Kwy1z4rJXRDwhOzo9kzGxQGI=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "aa7feb1548033cac9529f58bc84506f49bcce6fc",
+        "rev": "50da7a22dbc693907354807cd0dbef1b968d4656",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1775432390,
-        "narHash": "sha256-NgjfXCrJ/5LnZmCUW9R1yRI7vfxzLmuug5soF1vHiN0=",
+        "lastModified": 1776053931,
+        "narHash": "sha256-hIrokixXRDs62wDh1olLBbI9rVX3K0mWAGLaZn4awwQ=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "6354d34d59d783f4920e8413bd9bc883f8afb869",
+        "rev": "efe5fd9185ad528f39c76a3aee4bd4254b43adbd",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1775353191,
-        "narHash": "sha256-bK65+s0Xbt0fq5K/i9Ez02AbDv7HBSXEfdDhUlYphDg=",
+        "lastModified": 1775959049,
+        "narHash": "sha256-o2JFoAWll4ZuHnVKX2ld03ynKR2zkvTDxJ/ZTCDz2/I=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "2890b0f0d5edd3b5bf795294a04f9879d9d50fef",
+        "rev": "ec2b7be3c0b3b764aa0380fa32aa304a5b680cf8",
         "type": "github"
       },
       "original": {
@@ -449,6 +449,27 @@
         "type": "github"
       }
     },
+    "quickshell-upstream": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775720097,
+        "narHash": "sha256-p+vqkCuFfVNyQBo370wr6MebNUvz55RZiC0m8YKUhvQ=",
+        "owner": "quickshell-mirror",
+        "repo": "quickshell",
+        "rev": "d4c92973b53d9fa34cc110d3b974eb6bde5b3027",
+        "type": "github"
+      },
+      "original": {
+        "owner": "quickshell-mirror",
+        "repo": "quickshell",
+        "rev": "d4c92973b53d9fa34cc110d3b974eb6bde5b3027",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "authentik-nix": "authentik-nix",
@@ -465,6 +486,7 @@
         "nixpkgs": "nixpkgs",
         "nixpkgs-lib": "nixpkgs-lib",
         "opnix": "opnix",
+        "quickshell-upstream": "quickshell-upstream",
         "spacebarchat": "spacebarchat",
         "systems": "systems_2",
         "systems-linux": "systems-linux"
@@ -500,11 +522,11 @@
         "pion-webrtc": "pion-webrtc"
       },
       "locked": {
-        "lastModified": 1775431494,
-        "narHash": "sha256-YsUm2FuWUX2qGGK3GiY9zeERW/28Dj98yi4SuDI4Ax4=",
+        "lastModified": 1776021569,
+        "narHash": "sha256-inh5GWO8pYteqSD4aQ1dV38umBMw4BP4Fcs/5AIE1BI=",
         "owner": "spacebarchat",
         "repo": "server",
-        "rev": "b11ac9b4b4083e64dcf3089dea3b5ef2687829ab",
+        "rev": "afceef45b63aabdf764751e0c3171aa8b76a1269",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    quickshell-upstream = {
+      url = "github:quickshell-mirror/quickshell/d4c92973b53d9fa34cc110d3b974eb6bde5b3027";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     spacebarchat = {
       url = "github:spacebarchat/server";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/hosts/frame/configuration.nix
+++ b/hosts/frame/configuration.nix
@@ -46,6 +46,10 @@
     google-chrome
   ];
 
+  nixpkgs.overlays = [
+    (final: prev: inputs.quickshell-upstream.overlays.default final prev)
+  ];
+
   # Declarative WiFi configuration
   # NetworkManager will remember these networks and connect automatically
   networking.networkmanager = {

--- a/modules/common/users/config-files/configs/hyprland.nix
+++ b/modules/common/users/config-files/configs/hyprland.nix
@@ -83,13 +83,13 @@
         fi
       done
 
-      # Deploy Quickshell config
-      cp "${../files/quickshell}/shell.qml" "${homeDir}/.config/quickshell/shell.qml"
-      cp "${../files/quickshell}/Bar.qml" "${homeDir}/.config/quickshell/Bar.qml"
-      cp "${../files/quickshell}/Theme.qml" "${homeDir}/.config/quickshell/Theme.qml"
-      chmod 644 "${homeDir}/.config/quickshell/shell.qml"
-      chmod 644 "${homeDir}/.config/quickshell/Bar.qml"
-      chmod 644 "${homeDir}/.config/quickshell/Theme.qml"
+      # Deploy all Quickshell modules so component extraction works.
+      for qmlFile in ${../files/quickshell}/*.qml; do
+        if [ -f "$qmlFile" ]; then
+          cp "$qmlFile" "${homeDir}/.config/quickshell/"
+          chmod 644 "${homeDir}/.config/quickshell/$(basename "$qmlFile")"
+        fi
+      done
 
       # Deploy GTK settings
       cp "${../files/gtk/settings.ini}" "${homeDir}/.config/gtk-3.0/settings.ini"

--- a/modules/common/users/config-files/files/hypr/scripts/screenshot.sh
+++ b/modules/common/users/config-files/files/hypr/scripts/screenshot.sh
@@ -21,6 +21,12 @@ notify() {
     notify-send -u "$urgency" "Screenshot" "$message"
 }
 
+copy_image() {
+    local file="$1"
+    wl-copy --type image/png < "$file" >/dev/null 2>&1 &
+    disown
+}
+
 # Function to take screenshot
 take_screenshot() {
     local mode="$1"
@@ -29,22 +35,24 @@ take_screenshot() {
     case "$mode" in
         area)
             # Screenshot area with selection
-            grim -g "$(slurp)" - | tee "$filename" | wl-copy
-            notify "Saved to $filename and copied to clipboard. Swappy opened. Press Ctrl+S to save edits."
-            # Open in swappy for editing
-            swappy -f "$filename" -o "$filename"
+            grim -g "$(slurp)" "$filename"
+            copy_image "$filename"
+            notify "Saved to $filename and copied to clipboard. Swappy opened in background. Press Ctrl+S to save edits."
+            # Open in swappy for editing without blocking the script
+            swappy -f "$filename" -o "$filename" >/dev/null 2>&1 &
+            disown
             ;;
         full)
             # Full screen screenshot
             grim "$filename"
-            wl-copy < "$filename"
+            copy_image "$filename"
             notify "Saved to $filename and copied to clipboard"
             ;;
         window)
             # Active window screenshot
             local window_geometry=$(hyprctl -j activewindow | jq -r '"\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"')
             grim -g "$window_geometry" "$filename"
-            wl-copy < "$filename"
+            copy_image "$filename"
             notify "Saved to $filename and copied to clipboard"
             ;;
         *)

--- a/modules/common/users/config-files/files/quickshell/AccentButton.qml
+++ b/modules/common/users/config-files/files/quickshell/AccentButton.qml
@@ -1,0 +1,32 @@
+import QtQuick
+
+Rectangle {
+  id: root
+
+  property alias text: label.text
+  property color accent: Theme.purple
+  signal clicked
+
+  radius: 12
+  implicitHeight: 38
+  implicitWidth: label.implicitWidth + 28
+  color: accentMouse.containsMouse ? Qt.tint(accent, Qt.rgba(1, 1, 1, 0.15)) : Qt.tint(accent, Qt.rgba(0, 0, 0, 0.55))
+  border.width: 1
+  border.color: Qt.tint(accent, Qt.rgba(1, 1, 1, 0.08))
+
+  Text {
+    id: label
+    anchors.centerIn: parent
+    color: Theme.fg
+    font.family: Theme.monoFont
+    font.pixelSize: 13
+    font.weight: 700
+  }
+
+  HoverHandler { id: accentMouse }
+
+  MouseArea {
+    anchors.fill: parent
+    onClicked: root.clicked()
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/AudioPopup.qml
+++ b/modules/common/users/config-files/files/quickshell/AudioPopup.qml
@@ -1,0 +1,175 @@
+import Quickshell
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+PopupWindow {
+  id: root
+
+  required property var anchorItem
+  required property color popupColor
+  required property int popupWidth
+  required property int popupHeight
+  required property var sink
+  required property var runCommand
+  required property var setVolume
+
+  visible: false
+  grabFocus: true
+  color: popupColor
+  implicitWidth: popupWidth
+  implicitHeight: popupHeight
+
+  anchor.item: anchorItem
+  anchor.edges: Edges.Bottom | Edges.Left
+  anchor.gravity: Edges.Bottom | Edges.Right
+  anchor.margins.top: 12
+  anchor.adjustment: PopupAdjustment.All
+
+  Rectangle {
+    anchors.fill: parent
+    radius: 22
+    color: Theme.glass
+    border.width: 1
+    border.color: Theme.borderBright
+
+    Rectangle {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.top: parent.top
+      height: 68
+      radius: parent.radius
+      color: Qt.rgba(255 / 255, 0 / 255, 110 / 255, 0.08)
+    }
+
+    ColumnLayout {
+      anchors.fill: parent
+      anchors.margins: 18
+      spacing: 16
+
+      Text {
+        text: "Audio"
+        color: Theme.cyan
+        font.family: Theme.monoFont
+        font.pixelSize: 16
+        font.weight: 800
+      }
+
+      Text {
+        text: root.sink?.audio?.muted ? "Muted" : `Output level ${Theme.percent(volumeSlider.pressed ? volumeSlider.value : root.sink?.audio?.volume)}%`
+        color: Theme.fg
+        font.family: Theme.monoFont
+        font.pixelSize: 14
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        radius: 16
+        color: Theme.glassSoft
+        border.width: 1
+        border.color: Theme.border
+        implicitHeight: 56
+
+        RowLayout {
+          anchors.fill: parent
+          anchors.margins: 14
+          spacing: 12
+
+          Text {
+            text: Theme.audioIcon(root.sink?.audio?.volume || 0, root.sink?.audio?.muted || false, false)
+            color: Theme.pink
+            font.family: Theme.monoFont
+            font.pixelSize: 24
+          }
+
+          ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 2
+
+            Text {
+              text: root.sink?.description || "Default output"
+              color: Theme.fg
+              elide: Text.ElideRight
+              font.family: Theme.monoFont
+              font.pixelSize: 13
+              font.weight: 700
+            }
+
+            Text {
+              text: root.sink?.audio?.muted ? "Muted" : `${Theme.percent(volumeSlider.pressed ? volumeSlider.value : root.sink?.audio?.volume)}% volume`
+              color: Theme.fgMuted
+              font.family: Theme.monoFont
+              font.pixelSize: 12
+            }
+          }
+        }
+      }
+
+      Slider {
+        id: volumeSlider
+        from: 0
+        to: 1.5
+        live: true
+        value: 0
+        Layout.fillWidth: true
+
+        onPressedChanged: {
+          if (!pressed) root.setVolume(value)
+        }
+
+        background: Rectangle {
+          x: volumeSlider.leftPadding
+          y: volumeSlider.topPadding + volumeSlider.availableHeight / 2 - height / 2
+          width: volumeSlider.availableWidth
+          height: 10
+          radius: 999
+          color: Qt.rgba(224 / 255, 224 / 255, 224 / 255, 0.12)
+
+          Rectangle {
+            width: volumeSlider.visualPosition * parent.width
+            height: parent.height
+            radius: 999
+            color: Theme.cyan
+          }
+        }
+
+        handle: Rectangle {
+          x: volumeSlider.leftPadding + volumeSlider.visualPosition * (volumeSlider.availableWidth - width)
+          y: volumeSlider.topPadding + volumeSlider.availableHeight / 2 - height / 2
+          width: 18
+          height: 18
+          radius: 999
+          color: Theme.fg
+          border.width: 2
+          border.color: Theme.cyan
+        }
+      }
+
+      RowLayout {
+        spacing: 10
+
+        AccentButton {
+          text: root.sink?.audio?.muted ? "Unmute" : "Mute"
+          accent: Theme.pink
+          onClicked: if (root.sink?.audio) root.sink.audio.muted = !root.sink.audio.muted
+        }
+
+        AccentButton {
+          text: "Mixer"
+          accent: Theme.purple
+          onClicked: root.runCommand("pavucontrol")
+        }
+      }
+
+      Connections {
+        target: root.sink?.audio || null
+
+        function onVolumeChanged() {
+          if (!volumeSlider.pressed) volumeSlider.value = root.sink.audio.volume
+        }
+      }
+
+      Component.onCompleted: volumeSlider.value = root.sink?.audio?.volume || 0
+    }
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/Bar.qml
+++ b/modules/common/users/config-files/files/quickshell/Bar.qml
@@ -1,6 +1,7 @@
 import Quickshell
 import Quickshell.Hyprland
 import Quickshell.Io
+import Quickshell.Networking
 import Quickshell.Services.Pipewire
 import Quickshell.Services.SystemTray
 import Quickshell.Services.UPower
@@ -9,13 +10,14 @@ import Quickshell.Widgets
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import "."
 
 PanelWindow {
   id: root
 
   color: "transparent"
-  implicitHeight: 56
-  exclusiveZone: 56
+  implicitHeight: 50
+  exclusiveZone: 50
   aboveWindows: true
   focusable: false
 
@@ -26,21 +28,22 @@ PanelWindow {
   }
 
   margins {
-    left: 10
-    right: 10
-    top: 6
+    left: ShellGeometry.barLeft
+    right: ShellGeometry.barRight
+    top: ShellGeometry.barTop
   }
 
   property string openPopup: ""
   property string currentSubmap: "default"
-  property int chipHeight: 36
-  property bool wifiEnabled: false
-  property string wifiSsid: "offline"
-
-  readonly property var sink: Pipewire.defaultAudioSink
-  readonly property var battery: UPower.displayDevice
+  property int chipHeight: 32
+  property int popupWidth: 400
+  property int compactPopupHeight: 276
+  property int batteryPopupHeight: 330
+  property real pendingVolume: 0
+  readonly property int batteryPercent: Theme.batteryPercent(root.battery?.percentage)
+  readonly property int batteryHealthPercent: Theme.batteryPercent(root.battery?.healthPercentage)
   readonly property var activeToplevel: Hyprland.activeToplevel
-  readonly property var btAdapter: Bluetooth.defaultAdapter
+  property date preciseNow: new Date()
 
   function togglePopup(name) {
     openPopup = openPopup === name ? "" : name
@@ -48,13 +51,6 @@ PanelWindow {
 
   function run(command) {
     Hyprland.dispatch(`exec ${command}`)
-  }
-
-  function refreshNetwork() {
-    wifiStateProc.running = false
-    wifiSsidProc.running = false
-    wifiStateProc.running = true
-    wifiSsidProc.running = true
   }
 
   function workspaceVisible(workspace) {
@@ -69,39 +65,6 @@ PanelWindow {
     return Qt.rgba(16 / 255, 22 / 255, 50 / 255, 0.98)
   }
 
-  component AccentButton: Rectangle {
-    property alias text: label.text
-    property color accent: Theme.purple
-    signal clicked
-
-    radius: 12
-    implicitHeight: 38
-    implicitWidth: label.implicitWidth + 28
-    color: accentMouse.containsMouse ? Qt.tint(accent, Qt.rgba(1, 1, 1, 0.15)) : Qt.tint(accent, Qt.rgba(0, 0, 0, 0.55))
-    border.width: 1
-    border.color: Qt.tint(accent, Qt.rgba(1, 1, 1, 0.08))
-
-    Text {
-      id: label
-      anchors.centerIn: parent
-      color: Theme.fg
-      font.family: Theme.monoFont
-      font.pixelSize: 13
-      font.weight: 700
-    }
-
-    HoverHandler { id: accentMouse }
-
-    MouseArea {
-      anchors.fill: parent
-      onClicked: parent.clicked()
-    }
-  }
-
-  PwObjectTracker {
-    objects: [Pipewire.defaultAudioSink]
-  }
-
   Process {
     id: submapProc
     command: ["hyprctl", "submap"]
@@ -110,33 +73,6 @@ PanelWindow {
     stdout: StdioCollector {
       onStreamFinished: root.currentSubmap = text.trim()
     }
-  }
-
-  Process {
-    id: wifiStateProc
-    command: ["bash", "-lc", "nmcli -t -f WIFI g"]
-    running: true
-
-    stdout: StdioCollector {
-      onStreamFinished: root.wifiEnabled = text.trim() === "enabled"
-    }
-  }
-
-  Process {
-    id: wifiSsidProc
-    command: ["bash", "-lc", "nmcli -t -f ACTIVE,SSID dev wifi | awk -F: '$1==\"yes\" {print $2; exit}'"]
-    running: true
-
-    stdout: StdioCollector {
-      onStreamFinished: root.wifiSsid = text.trim() || (root.wifiEnabled ? "not connected" : "offline")
-    }
-  }
-
-  Timer {
-    interval: 15000
-    running: true
-    repeat: true
-    onTriggered: root.refreshNetwork()
   }
 
   Connections {
@@ -149,222 +85,59 @@ PanelWindow {
     }
   }
 
-  SystemClock {
-    id: systemClock
-    precision: SystemClock.Minutes
+  Timer {
+    interval: 25
+    running: true
+    repeat: true
+    onTriggered: root.preciseNow = new Date()
   }
 
   Rectangle {
     anchors.fill: parent
-    color: "transparent"
+    color: Qt.rgba(9 / 255, 13 / 255, 30 / 255, 0.7)
 
-    RowLayout {
-      id: leftRow
+    Rectangle {
       anchors.left: parent.left
-      anchors.leftMargin: 8
-      anchors.verticalCenter: parent.verticalCenter
-      spacing: 12
-
-      Rectangle {
-        id: controlCluster
-        radius: height / 2
-        color: Qt.rgba(17 / 255, 23 / 255, 47 / 255, 0.96)
-        border.width: 1
-        border.color: Theme.borderBright
-        implicitHeight: 48
-        implicitWidth: controlRow.implicitWidth + 8
-        Layout.alignment: Qt.AlignVCenter
-
-        Rectangle {
-          anchors.left: parent.left
-          anchors.right: parent.right
-          anchors.top: parent.top
-          anchors.margins: 1
-          height: parent.height / 2
-          radius: parent.radius
-          color: Qt.rgba(255 / 255, 255 / 255, 255 / 255, 0.03)
-        }
-
-        Row {
-          id: controlRow
-          anchors.fill: parent
-          anchors.margins: 4
-          spacing: 0
-
-          Rectangle {
-            id: notificationButton
-            radius: height / 2
-            color: notificationHover.hovered ? Qt.rgba(157 / 255, 78 / 255, 221 / 255, 0.28) : Qt.rgba(255 / 255, 255 / 255, 255 / 255, 0.02)
-            implicitWidth: notificationLabel.implicitWidth + 22
-            implicitHeight: root.chipHeight
-            width: implicitWidth
-            height: implicitHeight
-
-            Text {
-              id: notificationLabel
-              anchors.centerIn: parent
-              text: "notify"
-              color: Theme.cyan
-              font.family: Theme.monoFont
-              font.pixelSize: 13
-              font.weight: 800
-            }
-
-            HoverHandler { id: notificationHover }
-
-            MouseArea {
-              anchors.fill: parent
-              acceptedButtons: Qt.LeftButton | Qt.RightButton
-              onClicked: mouse => {
-                if (mouse.button === Qt.RightButton) {
-                  root.run("swaync-client -d -sw")
-                } else {
-                  root.run("swaync-client -t -sw")
-                }
-              }
-            }
-          }
-
-          Rectangle {
-            width: 1
-            height: root.chipHeight
-            anchors.verticalCenter: parent.verticalCenter
-            color: Qt.rgba(42 / 255, 51 / 255, 95 / 255, 0.7)
-          }
-
-          Rectangle {
-            id: audioButton
-            radius: 14
-            color: audioHover.hovered || root.openPopup === "audio" ? Qt.rgba(255 / 255, 0 / 255, 110 / 255, 0.16) : "transparent"
-            implicitWidth: audioLabel.implicitWidth + 32
-            implicitHeight: root.chipHeight
-            width: implicitWidth
-            height: implicitHeight
-
-            Text {
-              id: audioLabel
-              anchors.centerIn: parent
-              text: root.sink?.audio?.muted ? "audio muted" : `audio ${Theme.percent(root.sink?.audio?.volume)}%`
-              color: root.openPopup === "audio" ? Theme.cyan : Theme.fg
-              font.family: Theme.monoFont
-              font.pixelSize: 13
-              font.weight: 700
-            }
-
-            HoverHandler { id: audioHover }
-
-            MouseArea {
-              anchors.fill: parent
-              acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
-              onClicked: mouse => {
-                if (mouse.button === Qt.RightButton) {
-                  root.run("pavucontrol")
-                } else if (mouse.button === Qt.MiddleButton && root.sink?.audio) {
-                  root.sink.audio.muted = !root.sink.audio.muted
-                } else {
-                  root.togglePopup("audio")
-                }
-              }
-            }
-
-            WheelHandler {
-              onWheel: event => {
-                if (!root.sink?.audio) return
-                const delta = event.angleDelta.y > 0 ? 0.05 : -0.05
-                root.sink.audio.volume = Math.max(0, Math.min(1.5, root.sink.audio.volume + delta))
-              }
-            }
-          }
-
-          Rectangle {
-            id: batteryButton
-            radius: 14
-            color: batteryHover.hovered || root.openPopup === "battery" ? Qt.rgba(0 / 255, 240 / 255, 255 / 255, 0.12) : "transparent"
-            implicitWidth: batteryLabel.implicitWidth + 32
-            implicitHeight: root.chipHeight
-            width: implicitWidth
-            height: implicitHeight
-
-            Text {
-              id: batteryLabel
-              anchors.centerIn: parent
-              text: `power ${Math.round(root.battery?.percentage || 0)}%`
-              color: root.openPopup === "battery" ? Theme.yellow : Theme.fg
-              font.family: Theme.monoFont
-              font.pixelSize: 13
-              font.weight: 700
-            }
-
-            HoverHandler { id: batteryHover }
-
-            MouseArea {
-              anchors.fill: parent
-              acceptedButtons: Qt.LeftButton | Qt.RightButton
-              onClicked: mouse => {
-                if (mouse.button === Qt.RightButton) {
-                  root.run("~/.config/hypr/scripts/power-menu.sh")
-                } else {
-                  root.togglePopup("battery")
-                }
-              }
-            }
-          }
-
-          Rectangle {
-            id: clockButton
-            radius: height / 2
-            color: clockHover.hovered || root.openPopup === "clock" ? Qt.rgba(157 / 255, 78 / 255, 221 / 255, 0.24) : Qt.rgba(255 / 255, 255 / 255, 255 / 255, 0.02)
-            implicitWidth: clockLabel.implicitWidth + 34
-            implicitHeight: root.chipHeight
-            width: implicitWidth
-            height: implicitHeight
-
-            Text {
-              id: clockLabel
-              anchors.centerIn: parent
-              text: Theme.formatMinutes(systemClock.date)
-              color: root.openPopup === "clock" ? Theme.pink : Theme.fg
-              font.family: Theme.monoFont
-              font.pixelSize: 13
-              font.weight: 700
-            }
-
-            HoverHandler { id: clockHover }
-
-            MouseArea {
-              anchors.fill: parent
-              onClicked: root.togglePopup("clock")
-            }
-          }
-        }
-      }
+      anchors.right: parent.right
+      anchors.bottom: parent.bottom
+      height: 1
+      color: Qt.rgba(123 / 255, 137 / 255, 208 / 255, 0.16)
     }
 
-      Rectangle {
-        id: workspaceStrip
+    Rectangle {
+      id: workspaceStrip
       anchors.horizontalCenter: parent.horizontalCenter
       anchors.verticalCenter: parent.verticalCenter
       radius: height / 2
-      color: Qt.rgba(17 / 255, 23 / 255, 47 / 255, 0.92)
+      color: Qt.rgba(15 / 255, 20 / 255, 42 / 255, 0.82)
       border.width: 1
-      border.color: Qt.rgba(42 / 255, 51 / 255, 95 / 255, 0.95)
-        implicitHeight: 44
-        implicitWidth: workspaceRow.implicitWidth + 16
+      border.color: Qt.rgba(62 / 255, 76 / 255, 136 / 255, 0.24)
+      implicitHeight: 42
+      implicitWidth: workspaceRow.implicitWidth + 16
+
+      Rectangle {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: parent.height / 2
+        radius: parent.radius
+        color: Qt.rgba(255 / 255, 255 / 255, 255 / 255, 0.018)
+      }
 
       RowLayout {
         id: workspaceRow
         anchors.fill: parent
-          anchors.margins: 5
-          spacing: 6
+        anchors.margins: 5
+        spacing: 5
 
         Rectangle {
           visible: root.currentSubmap && root.currentSubmap !== "default"
-          radius: 12
+          radius: 11
           color: Qt.rgba(255 / 255, 234 / 255, 0 / 255, 0.18)
           border.width: 1
           border.color: Qt.rgba(255 / 255, 234 / 255, 0 / 255, 0.35)
-          implicitHeight: 32
-          implicitWidth: submapText.implicitWidth + 20
+          implicitHeight: 28
+          implicitWidth: submapText.implicitWidth + 16
 
           Text {
             id: submapText
@@ -372,7 +145,7 @@ PanelWindow {
             text: `mode ${root.currentSubmap}`
             color: Theme.yellow
             font.family: Theme.monoFont
-            font.pixelSize: 14
+            font.pixelSize: 12
             font.weight: 700
           }
         }
@@ -385,7 +158,7 @@ PanelWindow {
             readonly property bool shown: root.workspaceVisible(modelData)
 
             visible: shown
-            radius: 14
+            radius: 12
             color: modelData.focused
               ? Qt.rgba(255 / 255, 0 / 255, 110 / 255, 0.18)
               : modelData.active
@@ -395,8 +168,8 @@ PanelWindow {
                   : "transparent"
             border.width: modelData.focused ? 1 : 0
             border.color: modelData.focused ? Theme.cyan : "transparent"
-            implicitHeight: 32
-            implicitWidth: wsText.implicitWidth + 24
+            implicitHeight: 28
+            implicitWidth: wsText.implicitWidth + 20
 
             Text {
               id: wsText
@@ -404,7 +177,7 @@ PanelWindow {
               text: root.workspaceDisplay(modelData)
               color: modelData.focused ? Theme.cyan : (modelData.toplevels.count > 0 ? Theme.fg : Theme.fgMuted)
               font.family: Theme.monoFont
-              font.pixelSize: 14
+              font.pixelSize: 12
               font.weight: modelData.focused ? 700 : 600
             }
 
@@ -420,583 +193,75 @@ PanelWindow {
       }
     }
 
-    RowLayout {
-      id: rightRow
+    Rectangle {
+      id: clockButton
       anchors.right: parent.right
-      anchors.rightMargin: 8
+      anchors.rightMargin: 10
       anchors.verticalCenter: parent.verticalCenter
-      spacing: 10
-
-      Rectangle {
-        id: statusPill
-        radius: height / 2
-        color: Qt.rgba(17 / 255, 23 / 255, 47 / 255, 0.92)
-        border.width: 1
-        border.color: Theme.borderBright
-        implicitHeight: 44
-        implicitWidth: statusRow.implicitWidth + 20
-
-        Row {
-          id: statusRow
-          anchors.fill: parent
-          anchors.leftMargin: 10
-          anchors.rightMargin: 10
-          anchors.topMargin: 6
-          anchors.bottomMargin: 6
-          spacing: 8
-
-          Rectangle {
-            id: wifiButton
-            radius: 12
-            color: wifiHover.hovered ? Qt.rgba(0 / 255, 240 / 255, 255 / 255, 0.18) : Qt.rgba(255 / 255, 255 / 255, 255 / 255, 0.02)
-            implicitWidth: wifiLabel.implicitWidth + 22
-            implicitHeight: 30
-            width: implicitWidth
-            height: implicitHeight
-
-            Text {
-              id: wifiLabel
-              anchors.centerIn: parent
-              text: root.wifiEnabled ? `wifi ${root.wifiSsid}` : "wifi off"
-              color: root.openPopup === "wifi" ? Theme.cyan : (root.wifiEnabled ? Theme.cyan : Theme.fgMuted)
-              font.family: Theme.monoFont
-              font.pixelSize: 13
-              font.weight: 800
-            }
-
-            HoverHandler { id: wifiHover }
-
-            MouseArea {
-              anchors.fill: parent
-              acceptedButtons: Qt.LeftButton | Qt.RightButton
-              onClicked: mouse => {
-                if (mouse.button === Qt.RightButton) {
-                  root.run("nm-connection-editor")
-                } else {
-                  root.togglePopup("wifi")
-                }
-              }
-            }
-          }
-
-          Rectangle {
-            id: btButton
-            radius: 12
-            color: btHover.hovered ? Qt.rgba(157 / 255, 78 / 255, 221 / 255, 0.18) : Qt.rgba(255 / 255, 255 / 255, 255 / 255, 0.02)
-            implicitWidth: btLabel.implicitWidth + 22
-            implicitHeight: 30
-            width: implicitWidth
-            height: implicitHeight
-
-            Text {
-              id: btLabel
-              anchors.centerIn: parent
-              text: root.btAdapter?.enabled ? "bt on" : "bt off"
-              color: root.btAdapter?.enabled ? Theme.cyan : Theme.fgMuted
-              font.family: Theme.monoFont
-              font.pixelSize: 13
-              font.weight: 800
-            }
-
-            HoverHandler { id: btHover }
-
-            MouseArea {
-              anchors.fill: parent
-              acceptedButtons: Qt.LeftButton | Qt.RightButton
-              onClicked: mouse => {
-                if (mouse.button === Qt.RightButton) {
-                  root.run("blueman-manager")
-                } else if (root.btAdapter) {
-                  root.btAdapter.enabled = !root.btAdapter.enabled
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  PopupWindow {
-    id: wifiPopup
-    visible: root.openPopup === "wifi"
-    color: popupBackgroundColor()
-    implicitWidth: 360
-    implicitHeight: 230
-
-    anchor.item: wifiButton
-    anchor.edges: Edges.Bottom | Edges.Right
-    anchor.gravity: Edges.Bottom | Edges.Right
-    anchor.margins.top: 12
-    anchor.adjustment: PopupAdjustment.All
-
-    Rectangle {
-      anchors.fill: parent
-      radius: 22
-      color: Theme.glass
+      radius: 19
+      color: Qt.rgba(15 / 255, 20 / 255, 42 / 255, 0.82)
       border.width: 1
-      border.color: Theme.borderBright
+      border.color: Qt.rgba(68 / 255, 83 / 255, 154 / 255, 0.24)
+      implicitHeight: 42
+      implicitWidth: preciseClockRow.implicitWidth + 26
 
       Rectangle {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        height: 72
+        height: parent.height / 2
         radius: parent.radius
-        color: Qt.rgba(0 / 255, 240 / 255, 255 / 255, 0.08)
+        color: Qt.rgba(255 / 255, 255 / 255, 255 / 255, 0.018)
       }
 
-      ColumnLayout {
-        anchors.fill: parent
-        anchors.margins: 18
-        spacing: 14
+      RowLayout {
+        id: preciseClockRow
+        anchors.centerIn: parent
+        spacing: 2
 
         Text {
-          text: "Network"
+          id: preciseClock
+          text: Qt.formatDateTime(root.preciseNow, "h:mm:ss")
           color: Theme.cyan
           font.family: Theme.monoFont
-          font.pixelSize: 16
-          font.weight: 800
-        }
-
-        Rectangle {
-          Layout.fillWidth: true
-          radius: 16
-          color: Theme.glassSoft
-          border.width: 1
-          border.color: Theme.border
-          implicitHeight: 72
-
-          ColumnLayout {
-            anchors.fill: parent
-            anchors.margins: 14
-            spacing: 2
-
-            Text {
-              text: root.wifiEnabled ? "Wi-Fi enabled" : "Wi-Fi disabled"
-              color: Theme.fg
-              font.family: Theme.monoFont
-              font.pixelSize: 13
-              font.weight: 700
-            }
-
-            Text {
-              text: root.wifiSsid
-              color: Theme.fgMuted
-              font.family: Theme.monoFont
-              font.pixelSize: 12
-              elide: Text.ElideRight
-            }
-          }
-        }
-
-        RowLayout {
-          spacing: 10
-
-          AccentButton {
-            text: root.wifiEnabled ? "Disable" : "Enable"
-            accent: Theme.cyan
-            onClicked: {
-              root.run(root.wifiEnabled ? "nmcli radio wifi off" : "nmcli radio wifi on")
-              root.refreshNetwork()
-            }
-          }
-
-          AccentButton {
-            text: "Connections"
-            accent: Theme.purple
-            onClicked: root.run("nm-connection-editor")
-          }
-
-          AccentButton {
-            text: "Advanced"
-            accent: Theme.pink
-            onClicked: root.run("ghostty -e nmtui")
-          }
-        }
-      }
-    }
-  }
-
-  PopupWindow {
-    id: audioPopup
-    visible: root.openPopup === "audio"
-    color: popupBackgroundColor()
-    implicitWidth: 360
-    implicitHeight: 250
-
-    anchor.item: audioButton
-    anchor.edges: Edges.Bottom | Edges.Left
-    anchor.gravity: Edges.Bottom | Edges.Right
-    anchor.margins.top: 12
-    anchor.adjustment: PopupAdjustment.All
-
-    Rectangle {
-      anchors.fill: parent
-      radius: 22
-      color: Theme.glass
-      border.width: 1
-      border.color: Theme.borderBright
-
-      Rectangle {
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: parent.top
-        height: 68
-        radius: parent.radius
-        color: Qt.rgba(255 / 255, 0 / 255, 110 / 255, 0.08)
-      }
-
-      ColumnLayout {
-        anchors.fill: parent
-        anchors.margins: 18
-        spacing: 16
-
-        Text {
-          text: "Audio"
-          color: Theme.cyan
-          font.family: Theme.monoFont
-          font.pixelSize: 16
+          font.pixelSize: 18
           font.weight: 800
         }
 
         Text {
-          text: root.sink?.audio?.muted ? "Muted" : `Output level ${Theme.percent(root.sink?.audio?.volume)}%`
-          color: Theme.fg
+          text: Qt.formatDateTime(root.preciseNow, ".zzz")
+          color: Theme.fgMuted
           font.family: Theme.monoFont
-          font.pixelSize: 14
-        }
-
-        Rectangle {
-          Layout.fillWidth: true
-          radius: 16
-          color: Theme.glassSoft
-          border.width: 1
-          border.color: Theme.border
-          implicitHeight: 56
-
-          RowLayout {
-            anchors.fill: parent
-            anchors.margins: 14
-            spacing: 12
-
-            Text {
-              text: Theme.audioIcon(root.sink?.audio?.volume || 0, root.sink?.audio?.muted || false, false)
-              color: Theme.pink
-              font.family: Theme.monoFont
-              font.pixelSize: 24
-            }
-
-            ColumnLayout {
-              Layout.fillWidth: true
-              spacing: 2
-
-              Text {
-                text: root.sink?.description || "Default output"
-                color: Theme.fg
-                elide: Text.ElideRight
-                font.family: Theme.monoFont
-                font.pixelSize: 13
-                font.weight: 700
-              }
-
-              Text {
-                text: root.sink?.audio?.muted ? "Muted" : `${Theme.percent(root.sink?.audio?.volume)}% volume`
-                color: Theme.fgMuted
-                font.family: Theme.monoFont
-                font.pixelSize: 12
-              }
-            }
-          }
-        }
-
-        Slider {
-          id: volumeSlider
-          from: 0
-          to: 1.5
-          value: root.sink?.audio?.volume || 0
-          Layout.fillWidth: true
-
-          onMoved: {
-            if (root.sink?.audio) root.sink.audio.volume = value
-          }
-
-          background: Rectangle {
-            x: volumeSlider.leftPadding
-            y: volumeSlider.topPadding + volumeSlider.availableHeight / 2 - height / 2
-            width: volumeSlider.availableWidth
-            height: 10
-            radius: 999
-            color: Qt.rgba(224 / 255, 224 / 255, 224 / 255, 0.12)
-
-            Rectangle {
-              width: volumeSlider.visualPosition * parent.width
-              height: parent.height
-              radius: 999
-              color: Theme.cyan
-            }
-          }
-
-          handle: Rectangle {
-            x: volumeSlider.leftPadding + volumeSlider.visualPosition * (volumeSlider.availableWidth - width)
-            y: volumeSlider.topPadding + volumeSlider.availableHeight / 2 - height / 2
-            width: 18
-            height: 18
-            radius: 999
-            color: Theme.fg
-            border.width: 2
-            border.color: Theme.cyan
-          }
-        }
-
-        RowLayout {
-          spacing: 10
-
-          AccentButton {
-            text: root.sink?.audio?.muted ? "Unmute" : "Mute"
-            accent: Theme.pink
-            onClicked: if (root.sink?.audio) root.sink.audio.muted = !root.sink.audio.muted
-          }
-
-          AccentButton {
-            text: "Mixer"
-            accent: Theme.purple
-            onClicked: root.run("pavucontrol")
-          }
-        }
-      }
-    }
-  }
-
-  PopupWindow {
-    id: batteryPopup
-    visible: root.openPopup === "battery"
-    color: popupBackgroundColor()
-    implicitWidth: 340
-    implicitHeight: 248
-
-    anchor.item: batteryButton
-    anchor.edges: Edges.Bottom | Edges.Left
-    anchor.gravity: Edges.Bottom | Edges.Right
-    anchor.margins.top: 12
-    anchor.adjustment: PopupAdjustment.All
-
-    Rectangle {
-      anchors.fill: parent
-      radius: 22
-      color: Theme.glass
-      border.width: 1
-      border.color: Theme.borderBright
-
-      Rectangle {
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: parent.top
-        height: 72
-        radius: parent.radius
-        color: Qt.rgba(255 / 255, 234 / 255, 0 / 255, 0.07)
-      }
-
-      ColumnLayout {
-        anchors.fill: parent
-        anchors.margins: 18
-        spacing: 12
-
-        Text {
-          text: "Power"
-          color: Theme.yellow
-          font.family: Theme.monoFont
-          font.pixelSize: 16
-          font.weight: 800
-        }
-
-        Text {
-          text: `${Theme.batteryIcon(root.battery?.percentage || 0, (root.battery?.timeToFull || 0) > 0)}  ${Math.round(root.battery?.percentage || 0)}%`
-          color: Theme.fg
-          font.family: Theme.monoFont
-          font.pixelSize: 28
+          font.pixelSize: 12
           font.weight: 700
-        }
-
-        Rectangle {
-          Layout.fillWidth: true
-          radius: 16
-          color: Theme.glassSoft
-          border.width: 1
-          border.color: Theme.border
-          implicitHeight: 72
-
-          RowLayout {
-            anchors.fill: parent
-            anchors.margins: 14
-            spacing: 12
-
-            Rectangle {
-              radius: 14
-              color: Qt.rgba(255 / 255, 234 / 255, 0 / 255, 0.14)
-              implicitWidth: 48
-              implicitHeight: 48
-
-              Text {
-                anchors.centerIn: parent
-                text: Theme.batteryIcon(root.battery?.percentage || 0, (root.battery?.timeToFull || 0) > 0)
-                color: Theme.yellow
-                font.family: Theme.monoFont
-                font.pixelSize: 24
-              }
-            }
-
-            ColumnLayout {
-              Layout.fillWidth: true
-              spacing: 2
-
-              Text {
-                text: root.battery?.timeToFull > 0 ? "Charging" : "Battery"
-                color: Theme.fg
-                font.family: Theme.monoFont
-                font.pixelSize: 13
-                font.weight: 700
-              }
-
-              Text {
-                text: root.battery?.timeToFull > 0
-                  ? `Full in ${Theme.formatBatteryTime(root.battery.timeToFull)}`
-                  : (root.battery?.timeToEmpty > 0 ? `Remaining ${Theme.formatBatteryTime(root.battery.timeToEmpty)}` : "Power source steady")
-                color: Theme.fgMuted
-                font.family: Theme.monoFont
-                font.pixelSize: 12
-              }
-            }
-          }
+          Layout.alignment: Qt.AlignBottom
         }
 
         Text {
-          text: root.battery?.energyRate > 0 ? `Draw ${root.battery.energyRate.toFixed(1)}W` : "Energy rate unavailable"
-          color: Theme.fgMuted
+          text: Qt.formatDateTime(root.preciseNow, "AP")
+          color: Theme.fg
           font.family: Theme.monoFont
-          font.pixelSize: 13
+          font.pixelSize: 12
+          font.weight: 700
+          Layout.leftMargin: 4
+          Layout.alignment: Qt.AlignBottom
         }
+      }
 
-        Text {
-          text: root.battery?.healthSupported ? `Health ${Math.round(root.battery.healthPercentage)}%` : "Health unavailable"
-          color: Theme.fgMuted
-          font.family: Theme.monoFont
-          font.pixelSize: 13
-        }
-
-        RowLayout {
-          spacing: 10
-
-          AccentButton {
-            text: "Power"
-            accent: Theme.yellow
-            onClicked: root.run("~/.config/hypr/scripts/power-menu.sh")
-          }
-
-          AccentButton {
-            text: "Balanced"
-            accent: Theme.purple
-            onClicked: root.run("powerprofilesctl set balanced")
-          }
-
-          AccentButton {
-            text: "Saver"
-            accent: Theme.cyan
-            onClicked: root.run("powerprofilesctl set power-saver")
-          }
-        }
+      MouseArea {
+        anchors.fill: parent
+        onClicked: root.togglePopup("clock")
       }
     }
   }
 
-  PopupWindow {
+  ClockPopup {
     id: clockPopup
     visible: root.openPopup === "clock"
-    color: popupBackgroundColor()
-    implicitWidth: 360
-    implicitHeight: 250
-
-    anchor.item: clockButton
-    anchor.edges: Edges.Bottom | Edges.Right
-    anchor.gravity: Edges.Bottom | Edges.Right
-    anchor.margins.top: 12
-    anchor.adjustment: PopupAdjustment.All
-
-    Rectangle {
-      anchors.fill: parent
-      radius: 22
-      color: Theme.glass
-      border.width: 1
-      border.color: Theme.borderBright
-
-      Rectangle {
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: parent.top
-        height: 78
-        radius: parent.radius
-        color: Qt.rgba(157 / 255, 78 / 255, 221 / 255, 0.08)
-      }
-
-      ColumnLayout {
-        anchors.fill: parent
-        anchors.margins: 18
-        spacing: 14
-
-        Text {
-          text: "Clock"
-          color: Theme.pink
-          font.family: Theme.monoFont
-          font.pixelSize: 16
-          font.weight: 800
-        }
-
-        Text {
-          text: Theme.formatMinutes(systemClock.date)
-          color: Theme.fg
-          font.family: Theme.monoFont
-          font.pixelSize: 34
-          font.weight: 700
-        }
-
-        Text {
-          text: Theme.formatLongDate(systemClock.date)
-          color: Theme.cyan
-          font.family: Theme.monoFont
-          font.pixelSize: 14
-        }
-
-        Rectangle {
-          Layout.fillWidth: true
-          Layout.fillHeight: true
-          radius: 18
-          color: Qt.rgba(22 / 255, 30 / 255, 63 / 255, 0.72)
-          border.width: 1
-          border.color: Qt.rgba(42 / 255, 51 / 255, 95 / 255, 0.95)
-          implicitHeight: 98
-
-          ColumnLayout {
-            anchors.fill: parent
-            anchors.margins: 14
-            spacing: 8
-
-            Text {
-              text: Qt.formatDateTime(systemClock.date, "dddd")
-              color: Theme.yellow
-              font.family: Theme.monoFont
-              font.pixelSize: 20
-              font.weight: 800
-            }
-
-            Text {
-              text: Qt.formatDateTime(systemClock.date, "MMMM d, yyyy")
-              color: Theme.fg
-              font.family: Theme.monoFont
-              font.pixelSize: 14
-            }
-          }
-        }
-      }
-    }
+    anchorItem: clockButton
+    popupColor: popupBackgroundColor()
+    popupWidth: root.popupWidth
+    popupHeight: root.compactPopupHeight
+    currentDate: root.preciseNow
   }
 }

--- a/modules/common/users/config-files/files/quickshell/BatteryPopup.qml
+++ b/modules/common/users/config-files/files/quickshell/BatteryPopup.qml
@@ -1,0 +1,155 @@
+import Quickshell
+import QtQuick
+import QtQuick.Layouts
+
+PopupWindow {
+  id: root
+
+  required property var anchorItem
+  required property color popupColor
+  required property int popupWidth
+  required property int popupHeight
+  required property var battery
+  required property int batteryPercent
+  required property int batteryHealthPercent
+  required property var runCommand
+
+  visible: false
+  grabFocus: true
+  color: popupColor
+  implicitWidth: popupWidth
+  implicitHeight: popupHeight
+
+  anchor.item: anchorItem
+  anchor.edges: Edges.Bottom | Edges.Left
+  anchor.gravity: Edges.Bottom | Edges.Right
+  anchor.margins.top: 12
+  anchor.adjustment: PopupAdjustment.All
+
+  Rectangle {
+    anchors.fill: parent
+    radius: 22
+    color: Theme.glass
+    border.width: 1
+    border.color: Theme.borderBright
+
+    Rectangle {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.top: parent.top
+      height: 72
+      radius: parent.radius
+      color: Qt.rgba(255 / 255, 234 / 255, 0 / 255, 0.07)
+    }
+
+    ColumnLayout {
+      anchors.fill: parent
+      anchors.margins: 18
+      spacing: 12
+
+      Text {
+        text: "Power"
+        color: Theme.yellow
+        font.family: Theme.monoFont
+        font.pixelSize: 16
+        font.weight: 800
+      }
+
+      Text {
+        text: `${Theme.batteryIcon(root.batteryPercent, (root.battery?.timeToFull || 0) > 0)}  ${root.batteryPercent}%`
+        color: Theme.fg
+        font.family: Theme.monoFont
+        font.pixelSize: 28
+        font.weight: 700
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        radius: 16
+        color: Theme.glassSoft
+        border.width: 1
+        border.color: Theme.border
+        implicitHeight: 72
+
+        RowLayout {
+          anchors.fill: parent
+          anchors.margins: 14
+          spacing: 12
+
+          Rectangle {
+            radius: 14
+            color: Qt.rgba(255 / 255, 234 / 255, 0 / 255, 0.14)
+            implicitWidth: 48
+            implicitHeight: 48
+
+            Text {
+              anchors.centerIn: parent
+              text: Theme.batteryIcon(root.batteryPercent, (root.battery?.timeToFull || 0) > 0)
+              color: Theme.yellow
+              font.family: Theme.monoFont
+              font.pixelSize: 24
+            }
+          }
+
+          ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 2
+
+            Text {
+              text: root.battery?.timeToFull > 0 ? "Charging" : "Battery"
+              color: Theme.fg
+              font.family: Theme.monoFont
+              font.pixelSize: 13
+              font.weight: 700
+            }
+
+            Text {
+              text: root.battery?.timeToFull > 0
+                ? `Full in ${Theme.formatBatteryTime(root.battery.timeToFull)}`
+                : (root.battery?.timeToEmpty > 0 ? `Remaining ${Theme.formatBatteryTime(root.battery.timeToEmpty)}` : "Power source steady")
+              color: Theme.fgMuted
+              font.family: Theme.monoFont
+              font.pixelSize: 12
+            }
+          }
+        }
+      }
+
+      Text {
+        text: root.battery?.energyRate > 0 ? `Draw ${root.battery.energyRate.toFixed(1)}W` : "Energy rate unavailable"
+        color: Theme.fgMuted
+        font.family: Theme.monoFont
+        font.pixelSize: 13
+      }
+
+      Text {
+        text: root.battery?.healthSupported ? `Health ${root.batteryHealthPercent}%` : "Health unavailable"
+        color: Theme.fgMuted
+        font.family: Theme.monoFont
+        font.pixelSize: 13
+      }
+
+      RowLayout {
+        spacing: 10
+
+        AccentButton {
+          text: "Power"
+          accent: Theme.yellow
+          onClicked: root.runCommand("~/.config/hypr/scripts/power-menu.sh")
+        }
+
+        AccentButton {
+          text: "Balanced"
+          accent: Theme.purple
+          onClicked: root.runCommand("powerprofilesctl set balanced")
+        }
+
+        AccentButton {
+          text: "Saver"
+          accent: Theme.cyan
+          onClicked: root.runCommand("powerprofilesctl set power-saver")
+        }
+      }
+    }
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/ClockPopup.qml
+++ b/modules/common/users/config-files/files/quickshell/ClockPopup.qml
@@ -1,0 +1,102 @@
+import Quickshell
+import QtQuick
+import QtQuick.Layouts
+
+PopupWindow {
+  id: root
+
+  required property var anchorItem
+  required property color popupColor
+  required property int popupWidth
+  required property int popupHeight
+  required property date currentDate
+
+  visible: false
+  grabFocus: true
+  color: popupColor
+  implicitWidth: popupWidth
+  implicitHeight: popupHeight
+
+  anchor.item: anchorItem
+  anchor.edges: Edges.Bottom | Edges.Right
+  anchor.gravity: Edges.Bottom | Edges.Right
+  anchor.margins.top: 12
+  anchor.adjustment: PopupAdjustment.All
+
+  Rectangle {
+    anchors.fill: parent
+    radius: 22
+    color: Theme.glass
+    border.width: 1
+    border.color: Theme.borderBright
+
+    Rectangle {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.top: parent.top
+      height: 78
+      radius: parent.radius
+      color: Qt.rgba(157 / 255, 78 / 255, 221 / 255, 0.08)
+    }
+
+    ColumnLayout {
+      anchors.fill: parent
+      anchors.margins: 18
+      spacing: 14
+
+      Text {
+        text: "Clock"
+        color: Theme.pink
+        font.family: Theme.monoFont
+        font.pixelSize: 16
+        font.weight: 800
+      }
+
+      Text {
+        text: Theme.formatMinutes(root.currentDate)
+        color: Theme.fg
+        font.family: Theme.monoFont
+        font.pixelSize: 34
+        font.weight: 700
+      }
+
+      Text {
+        text: Theme.formatLongDate(root.currentDate)
+        color: Theme.cyan
+        font.family: Theme.monoFont
+        font.pixelSize: 14
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        radius: 18
+        color: Qt.rgba(22 / 255, 30 / 255, 63 / 255, 0.72)
+        border.width: 1
+        border.color: Qt.rgba(42 / 255, 51 / 255, 95 / 255, 0.95)
+        implicitHeight: 98
+
+        ColumnLayout {
+          anchors.fill: parent
+          anchors.margins: 14
+          spacing: 8
+
+          Text {
+            text: Qt.formatDateTime(root.currentDate, "dddd")
+            color: Theme.yellow
+            font.family: Theme.monoFont
+            font.pixelSize: 20
+            font.weight: 800
+          }
+
+          Text {
+            text: Qt.formatDateTime(root.currentDate, "MMMM d, yyyy")
+            color: Theme.fg
+            font.family: Theme.monoFont
+            font.pixelSize: 14
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/ScreenShell.qml
+++ b/modules/common/users/config-files/files/quickshell/ScreenShell.qml
@@ -1,0 +1,16 @@
+import Quickshell
+import "."
+
+Scope {
+  id: root
+
+  required property var screen
+
+  Bar {
+    screen: root.screen
+  }
+
+  Sidebar {
+    screen: root.screen
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/ShellGeometry.qml
+++ b/modules/common/users/config-files/files/quickshell/ShellGeometry.qml
@@ -1,0 +1,15 @@
+pragma Singleton
+
+import Quickshell
+
+Singleton {
+  readonly property int sidebarWidth: 78
+  readonly property int sidebarLeft: 12
+  readonly property int sidebarBottom: 14
+
+  readonly property int barHeight: 50
+  readonly property int barTop: 0
+  readonly property int barRight: 0
+  readonly property int barLeft: 0
+  readonly property int sidebarTop: 0
+}

--- a/modules/common/users/config-files/files/quickshell/Sidebar.qml
+++ b/modules/common/users/config-files/files/quickshell/Sidebar.qml
@@ -1,0 +1,174 @@
+import Quickshell
+import Quickshell.Bluetooth
+import Quickshell.Hyprland
+import Quickshell.Networking
+import Quickshell.Services.Pipewire
+import Quickshell.Services.UPower
+import QtQuick
+import QtQuick.Layouts
+import "."
+
+PanelWindow {
+  id: root
+
+  component RailIconButton: Rectangle {
+    id: buttonRoot
+
+    property alias icon: iconLabel.text
+    property color accent: Theme.cyan
+    property bool active: true
+    property bool compact: false
+    signal clicked
+    signal rightClicked
+
+    Layout.fillWidth: true
+    implicitHeight: compact ? 42 : 50
+    radius: compact ? 16 : 18
+    color: buttonMouse.containsMouse
+      ? Qt.rgba(255 / 255, 255 / 255, 255 / 255, active ? 0.075 : 0.042)
+      : Qt.rgba(255 / 255, 255 / 255, 255 / 255, active ? 0.032 : 0.016)
+    border.width: 1
+    border.color: active
+      ? Qt.tint(accent, Qt.rgba(1, 1, 1, buttonMouse.containsMouse ? 0.08 : 0.2))
+      : Qt.rgba(68 / 255, 83 / 255, 154 / 255, 0.18)
+
+    Text {
+      id: iconLabel
+      anchors.centerIn: parent
+      color: active ? buttonRoot.accent : Theme.fgMuted
+      font.family: Theme.monoFont
+      font.pixelSize: compact ? 14 : 18
+      font.weight: compact ? 600 : 700
+    }
+
+    HoverHandler { id: buttonMouse }
+
+    MouseArea {
+      anchors.fill: parent
+      acceptedButtons: Qt.LeftButton | Qt.RightButton
+      onClicked: mouse => {
+        if (mouse.button === Qt.RightButton) buttonRoot.rightClicked()
+        else buttonRoot.clicked()
+      }
+    }
+  }
+
+  color: "transparent"
+  implicitWidth: ShellGeometry.sidebarWidth
+  exclusiveZone: ShellGeometry.sidebarWidth
+  aboveWindows: true
+  focusable: false
+
+  anchors {
+    top: true
+    left: true
+    bottom: true
+  }
+
+  margins {
+    top: ShellGeometry.sidebarTop
+    left: ShellGeometry.sidebarLeft
+    bottom: ShellGeometry.sidebarBottom
+  }
+
+  readonly property var sink: Pipewire.defaultAudioSink
+  readonly property var battery: UPower.displayDevice
+  readonly property int batteryPercent: Theme.batteryPercent(battery?.percentage)
+  readonly property var btAdapter: Bluetooth.defaultAdapter
+  readonly property var networkDevices: Networking.devices.values
+  readonly property var wifiDevice: networkDevices.find(device => device.type === DeviceType.Wifi) || null
+  readonly property var wifiNetworks: wifiDevice ? wifiDevice.networks.values : []
+  readonly property var activeWifiNetwork: wifiNetworks.find(network => network.connected) || null
+
+  function run(command) {
+    Hyprland.dispatch(`exec ${command}`)
+  }
+
+  Rectangle {
+    anchors.fill: parent
+    radius: 0
+    color: Qt.rgba(9 / 255, 13 / 255, 30 / 255, 0.7)
+    border.width: 0
+
+    Rectangle {
+      anchors.right: parent.right
+      anchors.top: parent.top
+      anchors.bottom: parent.bottom
+      width: 1
+      color: Qt.rgba(123 / 255, 137 / 255, 208 / 255, 0.12)
+    }
+
+    ColumnLayout {
+      anchors.fill: parent
+      anchors.margins: 8
+      spacing: 8
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        spacing: 6
+
+        Rectangle {
+          Layout.fillWidth: true
+          implicitHeight: 8
+          radius: 16
+          color: "transparent"
+          border.width: 0
+        }
+
+        RailIconButton {
+          icon: activeWifiNetwork ? "󰤨" : (Networking.wifiEnabled ? "󰤥" : "󰤮")
+          accent: Theme.cyan
+          active: Networking.wifiEnabled
+          onClicked: Networking.wifiEnabled = !Networking.wifiEnabled
+          onRightClicked: root.run("nm-connection-editor")
+        }
+
+        RailIconButton {
+          icon: btAdapter?.enabled ? "󰂯" : "󰂲"
+          accent: Theme.purple
+          active: !!btAdapter?.enabled
+          onClicked: if (btAdapter) btAdapter.enabled = !btAdapter.enabled
+          onRightClicked: root.run("blueman-manager")
+        }
+
+        RailIconButton {
+          icon: sink?.audio?.muted ? "󰝟" : Theme.audioIcon(sink?.audio?.volume || 0, false, false)
+          accent: Theme.pink
+          active: !(sink?.audio?.muted ?? false)
+          onClicked: if (sink?.audio) sink.audio.muted = !sink.audio.muted
+          onRightClicked: root.run("pavucontrol")
+        }
+
+        RailIconButton {
+          icon: Theme.batteryIcon(batteryPercent, (battery?.timeToFull || 0) > 0)
+          accent: Theme.yellow
+          active: true
+          onClicked: root.run("~/.config/hypr/scripts/power-menu.sh")
+          onRightClicked: root.run("powerprofilesctl set balanced")
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        implicitHeight: 1
+        color: Qt.rgba(68 / 255, 83 / 255, 154 / 255, 0.12)
+      }
+
+      Item { Layout.fillHeight: true }
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignBottom
+        spacing: 0
+
+        RailIconButton {
+          icon: "󰐥"
+          compact: false
+          accent: Theme.yellow
+          active: true
+          onClicked: root.run("~/.config/hypr/scripts/power-menu.sh")
+        }
+      }
+    }
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/Theme.qml
+++ b/modules/common/users/config-files/files/quickshell/Theme.qml
@@ -65,8 +65,17 @@ Singleton {
     return "󰁺"
   }
 
+  function batteryPercent(value) {
+    if (!value) return 0
+    return Math.round(value <= 1 ? value * 100 : value)
+  }
+
   function formatMinutes(date) {
     return Qt.formatDateTime(date, "h:mm AP")
+  }
+
+  function formatPreciseTime(date) {
+    return Qt.formatDateTime(date, "h:mm:ss.zzz AP")
   }
 
   function formatLongDate(date) {

--- a/modules/common/users/config-files/files/quickshell/WifiPopup.qml
+++ b/modules/common/users/config-files/files/quickshell/WifiPopup.qml
@@ -1,0 +1,112 @@
+import Quickshell
+import Quickshell.Networking
+import QtQuick
+import QtQuick.Layouts
+
+PopupWindow {
+  id: root
+
+  required property var anchorItem
+  required property color popupColor
+  required property int popupWidth
+  required property int popupHeight
+  required property bool wifiEnabled
+  required property string wifiSsid
+  required property var runCommand
+
+  visible: false
+  grabFocus: true
+  color: popupColor
+  implicitWidth: popupWidth
+  implicitHeight: popupHeight
+
+  anchor.item: anchorItem
+  anchor.edges: Edges.Bottom | Edges.Right
+  anchor.gravity: Edges.Bottom | Edges.Right
+  anchor.margins.top: 12
+  anchor.adjustment: PopupAdjustment.All
+
+  Rectangle {
+    anchors.fill: parent
+    radius: 22
+    color: Theme.glass
+    border.width: 1
+    border.color: Theme.borderBright
+
+    Rectangle {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.top: parent.top
+      height: 72
+      radius: parent.radius
+      color: Qt.rgba(0 / 255, 240 / 255, 255 / 255, 0.08)
+    }
+
+    ColumnLayout {
+      anchors.fill: parent
+      anchors.margins: 18
+      spacing: 14
+
+      Text {
+        text: "Network"
+        color: Theme.cyan
+        font.family: Theme.monoFont
+        font.pixelSize: 16
+        font.weight: 800
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        radius: 16
+        color: Theme.glassSoft
+        border.width: 1
+        border.color: Theme.border
+        implicitHeight: 72
+
+        ColumnLayout {
+          anchors.fill: parent
+          anchors.margins: 14
+          spacing: 2
+
+          Text {
+            text: root.wifiEnabled ? "Wi-Fi enabled" : "Wi-Fi disabled"
+            color: Theme.fg
+            font.family: Theme.monoFont
+            font.pixelSize: 13
+            font.weight: 700
+          }
+
+          Text {
+            text: root.wifiSsid
+            color: Theme.fgMuted
+            font.family: Theme.monoFont
+            font.pixelSize: 12
+            elide: Text.ElideRight
+          }
+        }
+      }
+
+      RowLayout {
+        spacing: 10
+
+        AccentButton {
+          text: root.wifiEnabled ? "Disable" : "Enable"
+          accent: Theme.cyan
+          onClicked: Networking.wifiEnabled = !Networking.wifiEnabled
+        }
+
+        AccentButton {
+          text: "Connections"
+          accent: Theme.purple
+          onClicked: root.runCommand("nm-connection-editor")
+        }
+
+        AccentButton {
+          text: "Advanced"
+          accent: Theme.pink
+          onClicked: root.runCommand("ghostty -e nmtui")
+        }
+      }
+    }
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/shell.qml
+++ b/modules/common/users/config-files/files/quickshell/shell.qml
@@ -4,7 +4,7 @@ Scope {
   Variants {
     model: Quickshell.screens
 
-    Bar {
+    ScreenShell {
       required property var modelData
       screen: modelData
     }

--- a/modules/overlays/quickshell-master.nix
+++ b/modules/overlays/quickshell-master.nix
@@ -1,0 +1,5 @@
+{inputs}:
+final: prev:
+  # Reuse upstream's pinned overlay so the package is built in the current
+  # nixpkgs context instead of importing a second package set.
+  inputs.quickshell-upstream.overlays.default final prev

--- a/modules/overlays/quickshell-master.nix
+++ b/modules/overlays/quickshell-master.nix
@@ -1,5 +1,4 @@
-{inputs}:
-final: prev:
-  # Reuse upstream's pinned overlay so the package is built in the current
-  # nixpkgs context instead of importing a second package set.
-  inputs.quickshell-upstream.overlays.default final prev
+{inputs}: final: prev:
+# Reuse upstream's pinned overlay so the package is built in the current
+# nixpkgs context instead of importing a second package set.
+inputs.quickshell-upstream.overlays.default final prev


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- upgrade `frame` to a pinned upstream Quickshell build and refactor the desktop shell into modular Quickshell surfaces with a persistent left sidebar
- replace duplicated top-bar controls with a cleaner sidebar-first layout, add extracted popup components, and improve the local screenshot-driven desktop iteration workflow
- add a repo-local `linux-ricing-bigbang` skill that captures the stage, permission-gated rebuild, screenshot, and refine loop for desktop work in this repo

## Validation
- `nix develop -c colmena apply-local --impure --sudo`
- `grim /tmp/quickshell-current.png`
- `quickshell log --tail 80`