### PR TITLE
feat(frame): add FIDO2 LUKS unlock workflow

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,4 +17,5 @@
 - [Cloudflare](external-dependencies/cloudflare.md)
 - [UniFi and LAN](external-dependencies/unifi-and-lan.md)
 - [1Password and OpNix](external-dependencies/1password-and-opnix.md)
+- [Frame LUKS and YubiKey](runbooks/frame-luks-yubikey.md)
 - [Remote MCP OAuth](runbooks/remote-mcp-oauth.md)

--- a/docs/hosts/frame.md
+++ b/docs/hosts/frame.md
@@ -27,6 +27,8 @@
 
 `frame` uses Disko and a LUKS-on-btrfs layout.
 
+The root LUKS volume is configured for systemd-initrd unlock with an enrolled FIDO2 token as an alternative to the normal passphrase.
+
 The main subvolumes are:
 
 - `/`
@@ -34,6 +36,18 @@ The main subvolumes are:
 - `/nix`
 - `/persist`
 - `/var/log`
+
+## LUKS Unlock Model
+
+- the root LUKS mapping is `crypted`
+- the current encrypted partition is `/dev/nvme0n1p2`
+- boot uses `systemd` initrd instead of the older scripted initrd path
+- boot tries `fido2-device=auto` first, then falls back to passphrase after a short timeout
+- the Disko `passwordFile` entry is only for provisioning and is not the runtime unlock mechanism
+
+If the boot UI looks noisy or slightly alarming, that is expected. The successful path is to press the YubiKey when prompted by the initrd.
+
+For rebuild, recovery, or re-enrollment steps, see `docs/runbooks/frame-luks-yubikey.md`.
 
 ## How It Fits Into The System
 
@@ -52,3 +66,4 @@ It exists to:
 - `hosts/frame/hypr/monitors.conf`
 - `modules/nixos/default.nix`
 - `modules/common/`
+- `docs/runbooks/frame-luks-yubikey.md`

--- a/docs/runbooks/frame-luks-yubikey.md
+++ b/docs/runbooks/frame-luks-yubikey.md
@@ -1,0 +1,136 @@
+# Frame LUKS and YubiKey
+
+Use this runbook when setting up `frame` from scratch again, re-enrolling a YubiKey after a reset, or checking how the current boot unlock flow works.
+
+## Current Model
+
+`frame` uses:
+
+- Disko for partitioning
+- a LUKS2 root volume on `/dev/nvme0n1p2`
+- a mapped root device named `crypted`
+- `systemd` initrd for boot-time unlock
+- FIDO2 token unlock via `systemd-cryptenroll`
+- passphrase fallback if the token is not present
+
+The declarative host-side configuration lives in:
+
+- `hosts/frame/configuration.nix`
+- `hosts/frame/disko.nix`
+
+## Declarative Config
+
+`frame` needs all of the following in NixOS configuration:
+
+- `boot.initrd.systemd.enable = true;`
+- `boot.initrd.systemd.fido2.enable = true;`
+- `boot.initrd.availableKernelModules = [ "usbhid" ];`
+- `boot.initrd.luks.fido2Support = false;`
+- `boot.initrd.luks.devices.crypted.crypttabExtraOpts = [ "fido2-device=auto" "token-timeout=10s" ];`
+
+This keeps the old scripted-stage1 FIDO2 path disabled and lets `systemd-cryptsetup` handle the enrolled token.
+
+## Rebuild
+
+After changing the host config on `frame`, rebuild with:
+
+`nr`
+
+If the rebuild succeeds, the host side is ready for enrollment.
+
+## Fresh Enrollment
+
+Enroll the token on the existing LUKS device with touch-only unlock:
+
+```bash
+sudo systemd-cryptenroll /dev/nvme0n1p2 \
+  --fido2-device=auto \
+  --fido2-with-client-pin=no \
+  --fido2-with-user-presence=yes \
+  --fido2-with-user-verification=no
+```
+
+Expected behavior:
+
+- the command asks for the current LUKS passphrase
+- the token may ask for touch confirmation during enrollment
+- the enrollment adds a new `fido2` slot to the LUKS header
+
+To inspect the current slots:
+
+```bash
+sudo systemd-cryptenroll /dev/nvme0n1p2
+```
+
+The working state on `frame` is:
+
+- `password`
+- `recovery`
+- `fido2`
+
+## Recovery Key
+
+Add a recovery key if needed:
+
+```bash
+sudo systemd-cryptenroll /dev/nvme0n1p2 --recovery-key
+```
+
+This prints a machine-generated fallback key. Store it somewhere safe if you intend to rely on it.
+
+## If the YubiKey Already Has an Unknown FIDO2 PIN
+
+The current key on `frame` is a `YubiKey 5C Nano`. If the token already has a FIDO2 PIN set and it is unknown, reset only the FIDO application before re-enrolling.
+
+Inspect the FIDO state:
+
+```bash
+nix shell nixpkgs#yubikey-manager -c ykman fido info
+```
+
+Reset the FIDO app immediately after reinserting the key:
+
+```bash
+nix shell nixpkgs#yubikey-manager -c ykman fido reset -f
+```
+
+Notes:
+
+- this must run within a few seconds after reinserting the key
+- it wipes FIDO2 and U2F credentials on the YubiKey
+- it clears the existing FIDO2 PIN
+
+Verify reset state:
+
+```bash
+nix shell nixpkgs#yubikey-manager -c ykman fido info
+```
+
+## Boot Behavior
+
+Expected boot behavior after enrollment:
+
+1. With the YubiKey inserted, initrd prompts for the token and boot continues after touching the key.
+2. Without the YubiKey inserted, boot waits briefly and then falls back to the normal LUKS passphrase prompt.
+
+The early boot screen can look noisy or slightly broken even on the success path. On `frame`, that was normal during testing. If the token is present, try pressing the YubiKey before assuming boot failed.
+
+## Verifying the Token Is Visible in Userspace
+
+List FIDO2 devices:
+
+```bash
+systemd-cryptenroll --fido2-device=list
+```
+
+For the current `frame` setup, this should show the YubiKey as a usable FIDO2 token.
+
+## Re-Enrollment Flow After a Reset or New Install
+
+1. Rebuild `frame` with `nr`.
+2. Confirm `systemd-cryptenroll --fido2-device=list` sees the key.
+3. If needed, reset the YubiKey FIDO app.
+4. Enroll the token with `systemd-cryptenroll`.
+5. Verify slot state with `sudo systemd-cryptenroll /dev/nvme0n1p2`.
+6. Reboot once with the token inserted.
+7. Reboot once without the token to confirm passphrase fallback still works.

--- a/hosts/frame/configuration.nix
+++ b/hosts/frame/configuration.nix
@@ -27,6 +27,24 @@
 
   services.fwupd.enable = true;
 
+  boot.initrd = {
+    # Use the modern systemd initrd path so the root LUKS volume can be
+    # unlocked with a FIDO2 security key enrolled via systemd-cryptenroll.
+    systemd = {
+      enable = true;
+      fido2.enable = true;
+    };
+
+    availableKernelModules = ["usbhid"];
+    luks = {
+      fido2Support = false;
+      devices.crypted.crypttabExtraOpts = [
+        "fido2-device=auto"
+        "token-timeout=10s"
+      ];
+    };
+  };
+
   services.onepassword-secrets = {
     enable = true;
     tokenFile = "/etc/opnix-token";

--- a/hosts/frame/disko.nix
+++ b/hosts/frame/disko.nix
@@ -25,7 +25,8 @@
               content = {
                 type = "luks";
                 name = "crypted";
-                # Interactive password entry at boot
+                # Disko uses this during provisioning; boot-time unlock is
+                # configured separately through NixOS initrd settings.
                 passwordFile = "/tmp/secret.key";
                 settings = {
                   allowDiscards = true; # Enable TRIM for SSD

--- a/modules/common/users/config-files/files/hypr/autostart.conf
+++ b/modules/common/users/config-files/files/hypr/autostart.conf
@@ -9,6 +9,7 @@ exec-once = /run/current-system/sw/bin/awww-daemon
 exec-once = wl-paste --type text --watch cliphist store
 exec-once = wl-paste --type image --watch cliphist store
 exec-once = hyprpolkitagent
+exec-once = /run/current-system/sw/bin/1password --silent
 exec-once = /run/current-system/sw/bin/elephant
 exec-once = /run/current-system/sw/bin/walker --gapplication-service
 exec-once = nm-applet --indicator


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- switch `frame` root unlock to the modern systemd-initrd FIDO2 flow while keeping passphrase fallback for the LUKS root volume
- document the `frame` LUKS and YubiKey setup, reenrollment, and recovery workflow in host docs and a dedicated runbook

## Validation
- `nix develop -c alejandra hosts/frame/configuration.nix hosts/frame/disko.nix`
- `nix eval .#nixosConfigurations.frame.config.boot.initrd.systemd.enable`
- `nix eval .#nixosConfigurations.frame.config.boot.initrd.luks.devices.crypted.crypttabExtraOpts`
- `nr`
- `systemd-cryptenroll --fido2-device=list`
- `sudo systemd-cryptenroll /dev/nvme0n1p2`
