### PR TITLE
feat(shell): add network and bluetooth status chips

### DIFF
--- a/modules/common/users/config-files/files/quickshell/Bar.qml
+++ b/modules/common/users/config-files/files/quickshell/Bar.qml
@@ -34,6 +34,8 @@ PanelWindow {
   }
 
   property string openPopup: ""
+  property bool bluetoothPopupPinned: false
+  property bool networkPopupPinned: false
   property string currentSubmap: "default"
   property int chipHeight: 32
   property int popupWidth: 400
@@ -44,10 +46,40 @@ PanelWindow {
   readonly property int batteryHealthPercent: Theme.batteryPercent(root.battery?.healthPercentage)
   readonly property var activeToplevel: Hyprland.activeToplevel
   readonly property var primaryWorkspaceIds: [1, 2, 3]
+  readonly property var networkDevices: Networking.devices.values
+  readonly property var bluetoothAdapter: Bluetooth.defaultAdapter
+  readonly property var bluetoothDevices: Bluetooth.devices.values
+  readonly property var connectedBluetoothDevices: bluetoothDevices.filter(device => device.connected)
+  readonly property var primaryBluetoothDevice: connectedBluetoothDevices.length === 1 ? connectedBluetoothDevices[0] : null
+  readonly property var activeNetworkDevice: networkDevices.find(device => device.connected) || null
+  readonly property var wifiDevice: networkDevices.find(device => device.type === DeviceType.Wifi) || null
+  readonly property var wifiNetworks: wifiDevice ? wifiDevice.networks.values : []
+  readonly property var activeWifiNetwork: wifiNetworks.find(network => network.connected) || null
+  readonly property string activeInterfaceName: activeNetworkDevice?.name || wifiDevice?.name || ""
   property date preciseNow: new Date()
 
   function togglePopup(name) {
     openPopup = openPopup === name ? "" : name
+  }
+
+  function toggleNetworkPopup() {
+    root.networkPopupPinned = !root.networkPopupPinned
+  }
+
+  function toggleBluetoothPopup() {
+    root.bluetoothPopupPinned = !root.bluetoothPopupPinned
+  }
+
+  function dismissNetworkPopup() {
+    root.networkPopupPinned = false
+  }
+
+  function dismissBluetoothPopup() {
+    root.bluetoothPopupPinned = false
+  }
+
+  function openBluetoothSettings() {
+    root.run("blueman-manager")
   }
 
   function run(command) {
@@ -247,6 +279,94 @@ PanelWindow {
     }
 
     Rectangle {
+      id: bluetoothButton
+      anchors.right: networkButton.left
+      anchors.rightMargin: 8
+      anchors.verticalCenter: parent.verticalCenter
+      radius: 19
+      color: Qt.rgba(17 / 255, 24 / 255, 43 / 255, 0.86)
+      border.width: 1
+      border.color: bluetoothHover.hovered ? Qt.rgba(157 / 255, 78 / 255, 221 / 255, 0.34) : Qt.rgba(72 / 255, 83 / 255, 141 / 255, 0.3)
+      implicitHeight: 42
+      implicitWidth: 60
+
+      Rectangle {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: parent.height / 2
+        radius: parent.radius
+        color: Qt.rgba(255 / 255, 255 / 255, 255 / 255, 0.024)
+      }
+
+      BluetoothChip {
+        anchors.centerIn: parent
+        enabled: !!root.bluetoothAdapter?.enabled
+        connectedCount: root.connectedBluetoothDevices.length
+        hovered: bluetoothHover.hovered
+      }
+
+      HoverHandler { id: bluetoothHover }
+
+      MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onClicked: mouse => {
+          if (mouse.button === Qt.RightButton) root.openBluetoothSettings()
+          else root.toggleBluetoothPopup()
+        }
+      }
+    }
+
+    Rectangle {
+      id: networkButton
+      anchors.right: clockButton.left
+      anchors.rightMargin: 8
+      anchors.verticalCenter: parent.verticalCenter
+      radius: 19
+      color: Qt.rgba(17 / 255, 24 / 255, 43 / 255, 0.86)
+      border.width: 1
+      border.color: networkHover.hovered ? Qt.rgba(0 / 255, 240 / 255, 255 / 255, 0.34) : Qt.rgba(72 / 255, 83 / 255, 141 / 255, 0.3)
+      implicitHeight: 42
+      implicitWidth: 76
+
+      Rectangle {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: parent.height / 2
+        radius: parent.radius
+        color: Qt.rgba(255 / 255, 255 / 255, 255 / 255, 0.024)
+      }
+
+      NetworkStats {
+        id: networkStats
+        interfaceName: root.activeInterfaceName
+      }
+
+      NetworkMiniGraph {
+        anchors.centerIn: parent
+        downloadHistory: networkStats.downloadHistory
+        uploadHistory: networkStats.uploadHistory
+        maxRate: networkStats.graphMaxBps
+        downloadColor: Theme.cyan
+        uploadColor: Theme.pink
+        idleColor: Qt.rgba(72 / 255, 83 / 255, 141 / 255, 0.4)
+      }
+
+      HoverHandler { id: networkHover }
+
+      MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onClicked: mouse => {
+          if (mouse.button === Qt.RightButton) root.run("nm-connection-editor")
+          else root.toggleNetworkPopup()
+        }
+      }
+    }
+
+    Rectangle {
       id: clockButton
       anchors.right: parent.right
       anchors.rightMargin: 10
@@ -316,5 +436,35 @@ PanelWindow {
     popupWidth: root.popupWidth
     popupHeight: root.compactPopupHeight
     currentDate: root.preciseNow
+  }
+
+  NetworkPopup {
+    id: networkPopup
+    visible: root.networkPopupPinned || networkHover.hovered || popupHovered
+    anchorItem: networkButton
+    popupColor: popupBackgroundColor()
+    popupWidth: 320
+    pinnedOpen: root.networkPopupPinned
+    dismissPopup: root.dismissNetworkPopup
+    activeDevice: root.activeNetworkDevice
+    activeWifiNetwork: root.activeWifiNetwork
+    interfaceName: root.activeInterfaceName
+    downloadBps: networkStats.downloadBps
+    uploadBps: networkStats.uploadBps
+    peakDownloadBps: networkStats.peakDownloadBps
+    peakUploadBps: networkStats.peakUploadBps
+  }
+
+  BluetoothPopup {
+    id: bluetoothPopup
+    visible: root.bluetoothPopupPinned || bluetoothHover.hovered || popupHovered
+    anchorItem: bluetoothButton
+    popupColor: popupBackgroundColor()
+    popupWidth: 320
+    pinnedOpen: root.bluetoothPopupPinned
+    dismissPopup: root.dismissBluetoothPopup
+    adapter: root.bluetoothAdapter
+    connectedDevices: root.connectedBluetoothDevices
+    openSettings: root.openBluetoothSettings
   }
 }

--- a/modules/common/users/config-files/files/quickshell/BluetoothChip.qml
+++ b/modules/common/users/config-files/files/quickshell/BluetoothChip.qml
@@ -1,0 +1,68 @@
+import QtQuick
+import QtQuick.Layouts
+import "."
+
+Item {
+  id: root
+
+  required property bool enabled
+  required property int connectedCount
+  required property bool hovered
+
+  implicitWidth: 58
+  implicitHeight: 18
+
+  RowLayout {
+    anchors.centerIn: parent
+    spacing: 6
+
+    Text {
+      id: iconLabel
+      text: root.connectedCount > 0 ? "󰂯" : "󰂲"
+      color: root.connectedCount > 0
+        ? Theme.cyan
+        : (root.enabled ? Theme.fg : Qt.rgba(139 / 255, 147 / 255, 184 / 255, 0.65))
+      font.family: Theme.monoFont
+      font.pixelSize: 18
+      font.weight: 700
+      opacity: root.connectedCount > 0 ? 0.9 : 1
+
+      SequentialAnimation on opacity {
+        running: root.connectedCount > 0 && !root.hovered
+        loops: Animation.Infinite
+
+        NumberAnimation {
+          to: 0.72
+          duration: 1500
+          easing.type: Easing.InOutSine
+        }
+
+        NumberAnimation {
+          to: 0.96
+          duration: 1500
+          easing.type: Easing.InOutSine
+        }
+      }
+    }
+
+    Rectangle {
+      visible: root.connectedCount > 1
+      radius: 7
+      color: Qt.rgba(157 / 255, 78 / 255, 221 / 255, 0.16)
+      border.width: 1
+      border.color: Qt.rgba(157 / 255, 78 / 255, 221 / 255, 0.28)
+      implicitWidth: Math.max(16, badgeText.implicitWidth + 8)
+      implicitHeight: 16
+
+      Text {
+        id: badgeText
+        anchors.centerIn: parent
+        text: String(root.connectedCount)
+        color: Theme.purple
+        font.family: Theme.monoFont
+        font.pixelSize: 10
+        font.weight: 800
+      }
+    }
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/BluetoothPopup.qml
+++ b/modules/common/users/config-files/files/quickshell/BluetoothPopup.qml
@@ -1,0 +1,220 @@
+import Quickshell
+import Quickshell.Bluetooth
+import Quickshell.Widgets
+import QtQuick
+import QtQuick.Layouts
+import "."
+
+PopupWindow {
+  id: root
+
+  required property var anchorItem
+  required property color popupColor
+  required property int popupWidth
+  required property bool pinnedOpen
+  required property var dismissPopup
+  required property var adapter
+  required property var connectedDevices
+  required property var openSettings
+
+  property bool popupHovered: popupHover.hovered
+
+  visible: false
+  grabFocus: pinnedOpen
+  color: popupColor
+  implicitWidth: popupWidth
+  implicitHeight: connectedDevices.length > 0 ? 252 : 194
+
+  onVisibleChanged: {
+    if (!visible && root.pinnedOpen) root.dismissPopup()
+  }
+
+  function batteryPercent(device) {
+    return `${Math.round(Math.max(0, Math.min(1, Number(device?.battery || 0))) * 100)}%`
+  }
+
+  function connectionSummary() {
+    if (!root.adapter?.enabled) return "adapter off"
+    if (root.adapter?.discovering) return "scanning"
+    if (root.connectedDevices.length > 0) return `${root.connectedDevices.length} connected`
+    return "ready"
+  }
+
+  anchor.item: anchorItem
+  anchor.rect.x: anchorItem.width / 2 - width / 2
+  anchor.rect.y: anchorItem.height + 12
+  anchor.adjustment: PopupAdjustment.All
+
+  Rectangle {
+    anchors.fill: parent
+    radius: 22
+    color: Theme.glass
+    border.width: 1
+    border.color: Theme.borderBright
+
+    HoverHandler { id: popupHover }
+
+    ColumnLayout {
+      anchors.fill: parent
+      anchors.margins: 18
+      spacing: 12
+
+      RowLayout {
+        Layout.fillWidth: true
+
+        Text {
+          text: "bluetooth"
+          color: Theme.purple
+          font.family: Theme.monoFont
+          font.pixelSize: 14
+          font.weight: 800
+        }
+
+        Item { Layout.fillWidth: true }
+
+        Text {
+          text: root.connectionSummary()
+          color: Theme.fgMuted
+          font.family: Theme.monoFont
+          font.pixelSize: 12
+          font.weight: 700
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        radius: 16
+        color: Theme.glassSoft
+        border.width: 1
+        border.color: Theme.border
+        implicitHeight: 66
+
+        ColumnLayout {
+          anchors.fill: parent
+          anchors.margins: 14
+          spacing: 4
+
+          Text {
+            text: root.adapter?.name || "no adapter"
+            color: Theme.fg
+            font.family: Theme.monoFont
+            font.pixelSize: 13
+            font.weight: 700
+          }
+
+          Text {
+            text: root.adapter?.enabled
+              ? (root.adapter?.discovering ? "discoverable and scanning" : "powered and available")
+              : "disabled"
+            color: Theme.fgMuted
+            font.family: Theme.monoFont
+            font.pixelSize: 12
+          }
+        }
+      }
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        spacing: 10
+
+        Repeater {
+          model: root.connectedDevices
+
+          delegate: Rectangle {
+            required property var modelData
+
+            Layout.fillWidth: true
+            radius: 14
+            color: Theme.glassAlt
+            border.width: 1
+            border.color: Theme.border
+            implicitHeight: 58
+
+            RowLayout {
+              anchors.fill: parent
+              anchors.margins: 12
+              spacing: 10
+
+              Rectangle {
+                radius: 10
+                color: Qt.rgba(157 / 255, 78 / 255, 221 / 255, 0.14)
+                implicitWidth: 34
+                implicitHeight: 34
+
+                IconImage {
+                  anchors.centerIn: parent
+                  width: 18
+                  height: 18
+                  source: Quickshell.iconPath(modelData.icon, "bluetooth")
+                }
+              }
+
+              ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 1
+
+                Text {
+                  text: modelData.name || modelData.deviceName || "device"
+                  color: Theme.fg
+                  font.family: Theme.monoFont
+                  font.pixelSize: 12
+                  font.weight: 700
+                  elide: Text.ElideRight
+                }
+
+                Text {
+                  text: modelData.batteryAvailable ? "battery" : "connected"
+                  color: Theme.fgMuted
+                  font.family: Theme.monoFont
+                  font.pixelSize: 11
+                }
+              }
+
+              Text {
+                text: modelData.batteryAvailable ? root.batteryPercent(modelData) : ""
+                visible: modelData.batteryAvailable
+                color: Theme.cyan
+                font.family: Theme.monoFont
+                font.pixelSize: 12
+                font.weight: 800
+              }
+            }
+          }
+        }
+
+        Rectangle {
+          visible: root.connectedDevices.length === 0
+          Layout.fillWidth: true
+          radius: 14
+          color: Theme.glassAlt
+          border.width: 1
+          border.color: Theme.border
+          implicitHeight: 58
+
+          Text {
+            anchors.centerIn: parent
+            text: root.adapter?.enabled ? "no active devices" : "adapter is disabled"
+            color: Theme.fgMuted
+            font.family: Theme.monoFont
+            font.pixelSize: 12
+            font.weight: 700
+          }
+        }
+      }
+
+      Item { Layout.fillHeight: true }
+
+      RowLayout {
+        Layout.fillWidth: true
+
+        Item { Layout.fillWidth: true }
+
+        AccentButton {
+          text: "settings"
+          accent: Theme.purple
+          onClicked: root.openSettings()
+        }
+      }
+    }
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/NetworkMiniGraph.qml
+++ b/modules/common/users/config-files/files/quickshell/NetworkMiniGraph.qml
@@ -1,0 +1,66 @@
+import QtQuick
+
+Item {
+  id: root
+
+  required property var downloadHistory
+  required property var uploadHistory
+  required property real maxRate
+  required property color downloadColor
+  required property color uploadColor
+  required property color idleColor
+
+  implicitWidth: 52
+  implicitHeight: 18
+
+  onDownloadHistoryChanged: graph.requestPaint()
+  onUploadHistoryChanged: graph.requestPaint()
+  onMaxRateChanged: graph.requestPaint()
+  onWidthChanged: graph.requestPaint()
+  onHeightChanged: graph.requestPaint()
+
+  Canvas {
+    id: graph
+    anchors.fill: parent
+
+    function drawSeries(ctx, samples, color, baselineFactor, amplitudeFactor) {
+      if (!samples.length) return
+
+      const maxRate = Math.max(1, root.maxRate)
+      const step = samples.length > 1 ? width / (samples.length - 1) : width
+      ctx.beginPath()
+
+      for (let i = 0; i < samples.length; i++) {
+        const sample = Math.max(0, Number(samples[i] || 0))
+        const ratio = Math.min(1, sample / maxRate)
+        const x = samples.length > 1 ? i * step : width / 2
+        const baseline = height * baselineFactor
+        const y = baseline - ratio * height * amplitudeFactor
+
+        if (i === 0) ctx.moveTo(x, y)
+        else ctx.lineTo(x, y)
+      }
+
+      ctx.strokeStyle = color
+      ctx.lineWidth = 1.15
+      ctx.lineJoin = "round"
+      ctx.lineCap = "round"
+      ctx.stroke()
+    }
+
+    onPaint: {
+      const ctx = getContext("2d")
+      ctx.reset()
+
+      ctx.beginPath()
+      ctx.moveTo(0, height * 0.5)
+      ctx.lineTo(width, height * 0.5)
+      ctx.strokeStyle = root.idleColor
+      ctx.lineWidth = 0.75
+      ctx.stroke()
+
+      drawSeries(ctx, root.downloadHistory, root.downloadColor, 0.82, 0.34)
+      drawSeries(ctx, root.uploadHistory, root.uploadColor, 0.98, 0.2)
+    }
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/NetworkPopup.qml
+++ b/modules/common/users/config-files/files/quickshell/NetworkPopup.qml
@@ -1,0 +1,180 @@
+import Quickshell
+import Quickshell.Networking
+import QtQuick
+import QtQuick.Layouts
+
+PopupWindow {
+  id: root
+
+  required property var anchorItem
+  required property color popupColor
+  required property int popupWidth
+  required property bool pinnedOpen
+  required property var dismissPopup
+  required property var activeDevice
+  required property var activeWifiNetwork
+  required property string interfaceName
+  required property real downloadBps
+  required property real uploadBps
+  required property real peakDownloadBps
+  required property real peakUploadBps
+
+  property bool popupHovered: popupHover.hovered
+
+  visible: false
+  grabFocus: pinnedOpen
+  color: popupColor
+  implicitWidth: popupWidth
+  implicitHeight: 272
+
+  onVisibleChanged: {
+    if (!visible && root.pinnedOpen) root.dismissPopup()
+  }
+
+  function formatRate(rate) {
+    const units = ["B/s", "KB/s", "MB/s", "GB/s"]
+    let value = Math.max(0, Number(rate || 0))
+    let unitIndex = 0
+
+    while (value >= 1024 && unitIndex < units.length - 1) {
+      value /= 1024
+      unitIndex++
+    }
+
+    const digits = value >= 100 ? 0 : value >= 10 ? 1 : 2
+    return `${value.toFixed(digits)} ${units[unitIndex]}`
+  }
+
+  function percent(value) {
+    return `${Math.round(Math.max(0, Math.min(1, Number(value || 0))) * 100)}%`
+  }
+
+  function networkKind() {
+    if (root.activeDevice?.type === DeviceType.Wifi) return "wifi"
+    if (root.activeDevice?.connected) return "ethernet"
+    return "offline"
+  }
+
+  anchor.item: anchorItem
+  anchor.rect.x: anchorItem.width / 2 - width / 2
+  anchor.rect.y: anchorItem.height + 12
+  anchor.adjustment: PopupAdjustment.All
+
+  Rectangle {
+    anchors.fill: parent
+    radius: 22
+    color: Theme.glass
+    border.width: 1
+    border.color: Theme.borderBright
+
+    HoverHandler { id: popupHover }
+
+    ColumnLayout {
+      anchors.fill: parent
+      anchors.margins: 18
+      spacing: 12
+
+      RowLayout {
+        Layout.fillWidth: true
+
+        Text {
+          text: root.networkKind()
+          color: Theme.cyan
+          font.family: Theme.monoFont
+          font.pixelSize: 14
+          font.weight: 800
+        }
+
+        Item { Layout.fillWidth: true }
+
+        Text {
+          text: root.interfaceName || "no-link"
+          color: Theme.fgMuted
+          font.family: Theme.monoFont
+          font.pixelSize: 12
+          font.weight: 700
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        radius: 16
+        color: Theme.glassSoft
+        border.width: 1
+        border.color: Theme.border
+        implicitHeight: 72
+
+        ColumnLayout {
+          anchors.fill: parent
+          anchors.margins: 14
+          spacing: 4
+
+          Text {
+            text: root.activeWifiNetwork?.name || (root.activeDevice?.connected ? "wired connection" : "not connected")
+            color: Theme.fg
+            font.family: Theme.monoFont
+            font.pixelSize: 13
+            font.weight: 700
+            elide: Text.ElideRight
+          }
+
+          Text {
+            text: root.activeWifiNetwork ? `signal ${root.percent(root.activeWifiNetwork.signalStrength)}` : (root.activeDevice?.connected ? "link active" : "waiting for network")
+            color: Theme.fgMuted
+            font.family: Theme.monoFont
+            font.pixelSize: 12
+          }
+        }
+      }
+
+      GridLayout {
+        Layout.fillWidth: true
+        columns: 2
+        columnSpacing: 12
+        rowSpacing: 10
+
+        Repeater {
+          model: [
+            { label: "down", value: root.formatRate(root.downloadBps), accent: Theme.cyan },
+            { label: "up", value: root.formatRate(root.uploadBps), accent: Theme.pink },
+            { label: "down peak", value: root.formatRate(root.peakDownloadBps), accent: Theme.blue },
+            { label: "up peak", value: root.formatRate(root.peakUploadBps), accent: Theme.purple }
+          ]
+
+          delegate: Rectangle {
+            required property var modelData
+
+            Layout.fillWidth: true
+            radius: 14
+            color: Theme.glassAlt
+            border.width: 1
+            border.color: Theme.border
+            implicitHeight: 58
+
+            ColumnLayout {
+              anchors.fill: parent
+              anchors.margins: 12
+              spacing: 2
+
+              Text {
+                text: modelData.label
+                color: Theme.fgMuted
+                font.family: Theme.monoFont
+                font.pixelSize: 11
+                font.weight: 700
+              }
+
+              Text {
+                text: modelData.value
+                color: modelData.accent
+                font.family: Theme.monoFont
+                font.pixelSize: 13
+                font.weight: 800
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/NetworkStats.qml
+++ b/modules/common/users/config-files/files/quickshell/NetworkStats.qml
@@ -1,0 +1,103 @@
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+Scope {
+  id: root
+
+  property string interfaceName: ""
+  property real downloadBps: 0
+  property real uploadBps: 0
+  property real peakDownloadBps: 0
+  property real peakUploadBps: 0
+  property real graphMaxBps: 1
+  property var downloadHistory: []
+  property var uploadHistory: []
+
+  property int sampleCount: 24
+  property int sampleInterval: 1000
+  property real _previousRxBytes: -1
+  property real _previousTxBytes: -1
+
+  function reset() {
+    root.downloadBps = 0
+    root.uploadBps = 0
+    root.peakDownloadBps = 0
+    root.peakUploadBps = 0
+    root.graphMaxBps = 1
+    root.downloadHistory = []
+    root.uploadHistory = []
+    root._previousRxBytes = -1
+    root._previousTxBytes = -1
+  }
+
+  function appendSample(history, value) {
+    const next = history.slice()
+    next.push(value)
+    return next.slice(-root.sampleCount)
+  }
+
+  function updateSeries(rxBytes, txBytes) {
+    if (root._previousRxBytes < 0 || root._previousTxBytes < 0) {
+      root._previousRxBytes = rxBytes
+      root._previousTxBytes = txBytes
+      return
+    }
+
+    const rxDelta = Math.max(0, rxBytes - root._previousRxBytes)
+    const txDelta = Math.max(0, txBytes - root._previousTxBytes)
+    const intervalSeconds = root.sampleInterval / 1000
+    const downloadBps = rxDelta / intervalSeconds
+    const uploadBps = txDelta / intervalSeconds
+
+    root._previousRxBytes = rxBytes
+    root._previousTxBytes = txBytes
+    root.downloadBps = downloadBps
+    root.uploadBps = uploadBps
+    root.downloadHistory = root.appendSample(root.downloadHistory, downloadBps)
+    root.uploadHistory = root.appendSample(root.uploadHistory, uploadBps)
+
+    const rxPeak = root.downloadHistory.length ? Math.max(...root.downloadHistory) : 0
+    const txPeak = root.uploadHistory.length ? Math.max(...root.uploadHistory) : 0
+    root.peakDownloadBps = rxPeak
+    root.peakUploadBps = txPeak
+    root.graphMaxBps = Math.max(1, rxPeak, txPeak)
+  }
+
+  function parseCounters(text) {
+    if (!root.interfaceName) {
+      root.reset()
+      return
+    }
+
+    const lines = String(text || "").split("\n")
+    for (const line of lines) {
+      if (!line.includes(":")) continue
+
+      const fields = line.trim().split(/[:\s]+/)
+      if (fields[0] !== root.interfaceName) continue
+
+      root.updateSeries(Number(fields[1] || 0), Number(fields[9] || 0))
+      return
+    }
+
+    root.reset()
+  }
+
+  onInterfaceNameChanged: reset()
+
+  Timer {
+    interval: root.sampleInterval
+    running: true
+    repeat: true
+    triggeredOnStart: true
+    onTriggered: sampleProc.exec(["cat", "/proc/net/dev"])
+  }
+
+  Process {
+    id: sampleProc
+    stdout: StdioCollector {
+      onStreamFinished: root.parseCounters(text)
+    }
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/Sidebar.qml
+++ b/modules/common/users/config-files/files/quickshell/Sidebar.qml
@@ -1,7 +1,5 @@
 import Quickshell
-import Quickshell.Bluetooth
 import Quickshell.Hyprland
-import Quickshell.Networking
 import Quickshell.Services.Pipewire
 import Quickshell.Services.UPower
 import QtQuick
@@ -74,11 +72,6 @@ PanelWindow {
   readonly property var sink: Pipewire.defaultAudioSink
   readonly property var battery: UPower.displayDevice
   readonly property int batteryPercent: Theme.batteryPercent(battery?.percentage)
-  readonly property var btAdapter: Bluetooth.defaultAdapter
-  readonly property var networkDevices: Networking.devices.values
-  readonly property var wifiDevice: networkDevices.find(device => device.type === DeviceType.Wifi) || null
-  readonly property var wifiNetworks: wifiDevice ? wifiDevice.networks.values : []
-  readonly property var activeWifiNetwork: wifiNetworks.find(network => network.connected) || null
   property var openPowerMenu: null
 
   function run(command) {
@@ -114,22 +107,6 @@ PanelWindow {
           radius: 16
           color: "transparent"
           border.width: 0
-        }
-
-        RailIconButton {
-          icon: activeWifiNetwork ? "󰤨" : (Networking.wifiEnabled ? "󰤥" : "󰤮")
-          accent: Theme.cyan
-          active: Networking.wifiEnabled
-          onClicked: Networking.wifiEnabled = !Networking.wifiEnabled
-          onRightClicked: root.run("nm-connection-editor")
-        }
-
-        RailIconButton {
-          icon: btAdapter?.enabled ? "󰂯" : "󰂲"
-          accent: Theme.purple
-          active: !!btAdapter?.enabled
-          onClicked: if (btAdapter) btAdapter.enabled = !btAdapter.enabled
-          onRightClicked: root.run("blueman-manager")
         }
 
         RailIconButton {


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- add compact network and bluetooth status chips to the Quickshell top bar, including hover popups for throughput, connection state, bluetooth devices, and battery information
- replace the old sidebar wifi and bluetooth controls with richer top-bar status surfaces and interaction flows that match the shell's visual language
- polish the new chips with centered popups, hover/click dismissal, streamlined bluetooth labeling, and tighter bar spacing

## Validation
- `timeout 5s quickshell -vv -p "modules/common/users/config-files/files/quickshell/shell.qml"`