### PR TITLE
feat(shell): add audio status chip

### DIFF
--- a/modules/common/users/config-files/files/quickshell/AudioChip.qml
+++ b/modules/common/users/config-files/files/quickshell/AudioChip.qml
@@ -1,0 +1,45 @@
+import QtQuick
+import QtQuick.Layouts
+import "."
+
+Item {
+  id: root
+
+  required property real volume
+  required property bool muted
+  required property bool hovered
+
+  implicitWidth: 30
+  implicitHeight: 18
+
+  ColumnLayout {
+    anchors.centerIn: parent
+    spacing: 4
+
+    Text {
+      text: Theme.audioIcon(root.volume, root.muted, false)
+      color: root.hovered ? Theme.pink : (root.muted ? Theme.fgMuted : Theme.fg)
+      font.family: Theme.monoFont
+      font.pixelSize: 18
+      font.weight: 700
+      Layout.alignment: Qt.AlignHCenter
+    }
+
+    Rectangle {
+      radius: 999
+      color: Qt.rgba(72 / 255, 83 / 255, 141 / 255, 0.24)
+      implicitWidth: 18
+      implicitHeight: 3
+      Layout.alignment: Qt.AlignHCenter
+
+      Rectangle {
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        width: root.muted ? 0 : Math.max(2, parent.width * Math.min(1, Math.max(0, root.volume / 1.5)))
+        radius: parent.radius
+        color: Theme.pink
+      }
+    }
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/AudioPopup.qml
+++ b/modules/common/users/config-files/files/quickshell/AudioPopup.qml
@@ -1,7 +1,8 @@
 import Quickshell
+import Quickshell.Services.Pipewire
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Layouts
+import "."
 
 PopupWindow {
   id: root
@@ -9,21 +10,52 @@ PopupWindow {
   required property var anchorItem
   required property color popupColor
   required property int popupWidth
-  required property int popupHeight
   required property var sink
+  required property var sinks
   required property var runCommand
-  required property var setVolume
+  required property bool pinnedOpen
+  required property var dismissPopup
 
   visible: false
-  grabFocus: true
+  grabFocus: pinnedOpen
   color: popupColor
   implicitWidth: popupWidth
-  implicitHeight: popupHeight
+  implicitHeight: 360
+
+  property bool popupHovered: popupHover.hovered
+
+  function sinkLabel(sink) {
+    return sink?.description || sink?.nickname || sink?.name || "output"
+  }
+
+  function isCurrentSink(candidate) {
+    return candidate && root.sink && candidate.id === root.sink.id
+  }
+
+  function availableAlternateSinks() {
+    return (root.sinks || []).filter(candidate => candidate && !root.isCurrentSink(candidate))
+  }
+
+  function currentVolume() {
+    return root.sink?.audio?.volume || 0
+  }
+
+  function setVolume(nextVolume) {
+    if (!root.sink?.audio) return
+    root.sink.audio.volume = Math.max(0, Math.min(1.0, nextVolume))
+  }
+
+  function nudgeVolume(delta) {
+    root.setVolume(root.currentVolume() + delta)
+  }
+
+  onVisibleChanged: {
+    if (!visible && root.pinnedOpen) root.dismissPopup()
+  }
 
   anchor.item: anchorItem
-  anchor.edges: Edges.Bottom | Edges.Left
-  anchor.gravity: Edges.Bottom | Edges.Right
-  anchor.margins.top: 12
+  anchor.rect.x: anchorItem.width / 2 - width / 2
+  anchor.rect.y: anchorItem.height + 12
   anchor.adjustment: PopupAdjustment.All
 
   Rectangle {
@@ -33,33 +65,25 @@ PopupWindow {
     border.width: 1
     border.color: Theme.borderBright
 
-    Rectangle {
-      anchors.left: parent.left
-      anchors.right: parent.right
-      anchors.top: parent.top
-      height: 68
-      radius: parent.radius
-      color: Qt.rgba(0 / 255, 240 / 255, 255 / 255, 0.07)
-    }
+    HoverHandler { id: popupHover }
 
     ColumnLayout {
       anchors.fill: parent
       anchors.margins: 18
-      spacing: 16
+      spacing: 12
 
-      Text {
-        text: "Audio"
-        color: Theme.cyan
-        font.family: Theme.monoFont
-        font.pixelSize: 16
-        font.weight: 800
-      }
+      RowLayout {
+        Layout.fillWidth: true
 
-      Text {
-        text: root.sink?.audio?.muted ? "Muted" : `Output level ${Theme.percent(volumeSlider.pressed ? volumeSlider.value : root.sink?.audio?.volume)}%`
-        color: Theme.fg
-        font.family: Theme.monoFont
-        font.pixelSize: 14
+        Text {
+          text: "audio"
+          color: Theme.pink
+          font.family: Theme.monoFont
+          font.pixelSize: 14
+          font.weight: 800
+        }
+
+        Item { Layout.fillWidth: true }
       }
 
       Rectangle {
@@ -68,7 +92,7 @@ PopupWindow {
         color: Theme.glassSoft
         border.width: 1
         border.color: Theme.border
-        implicitHeight: 56
+        implicitHeight: 64
 
         RowLayout {
           anchors.fill: parent
@@ -87,7 +111,7 @@ PopupWindow {
             spacing: 2
 
             Text {
-              text: root.sink?.description || "Default output"
+              text: root.sinkLabel(root.sink)
               color: Theme.fg
               elide: Text.ElideRight
               font.family: Theme.monoFont
@@ -96,7 +120,7 @@ PopupWindow {
             }
 
             Text {
-              text: root.sink?.audio?.muted ? "Muted" : `${Theme.percent(volumeSlider.pressed ? volumeSlider.value : root.sink?.audio?.volume)}% volume`
+              text: root.sink?.audio?.muted ? "Muted" : "Default output"
               color: Theme.fgMuted
               font.family: Theme.monoFont
               font.pixelSize: 12
@@ -105,43 +129,135 @@ PopupWindow {
         }
       }
 
-      Slider {
-        id: volumeSlider
-        from: 0
-        to: 1.5
-        live: true
-        value: 0
+      ColumnLayout {
         Layout.fillWidth: true
+        spacing: 10
 
-        onPressedChanged: {
-          if (!pressed) root.setVolume(value)
-        }
-
-        background: Rectangle {
-          x: volumeSlider.leftPadding
-          y: volumeSlider.topPadding + volumeSlider.availableHeight / 2 - height / 2
-          width: volumeSlider.availableWidth
-          height: 10
+        Rectangle {
+          Layout.fillWidth: true
+          implicitHeight: 10
           radius: 999
           color: Qt.rgba(139 / 255, 147 / 255, 184 / 255, 0.18)
 
           Rectangle {
-            width: volumeSlider.visualPosition * parent.width
+            width: parent.width * Math.min(1, Math.max(0, root.currentVolume()))
             height: parent.height
             radius: 999
             color: Theme.cyan
           }
         }
 
-        handle: Rectangle {
-          x: volumeSlider.leftPadding + volumeSlider.visualPosition * (volumeSlider.availableWidth - width)
-          y: volumeSlider.topPadding + volumeSlider.availableHeight / 2 - height / 2
-          width: 18
-          height: 18
-          radius: 999
-          color: Theme.fg
-          border.width: 2
-          border.color: Theme.cyan
+        RowLayout {
+          Layout.fillWidth: true
+          spacing: 10
+
+          AccentButton {
+            text: "−"
+            accent: Theme.purple
+            onClicked: root.nudgeVolume(-0.05)
+          }
+
+          Item { Layout.fillWidth: true }
+
+          Text {
+            text: root.sink?.audio?.muted ? "muted" : `${Theme.percent(root.currentVolume())}`
+            color: Theme.fg
+            font.family: Theme.monoFont
+            font.pixelSize: 12
+            font.weight: 700
+            Layout.alignment: Qt.AlignVCenter
+          }
+
+          Item { Layout.fillWidth: true }
+
+          AccentButton {
+            text: "+"
+            accent: Theme.cyan
+            onClicked: root.nudgeVolume(0.05)
+          }
+        }
+      }
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        spacing: 8
+
+        Text {
+          text: root.availableAlternateSinks().length > 0 ? "outputs" : "no other outputs"
+          color: Theme.fgMuted
+          font.family: Theme.monoFont
+          font.pixelSize: 11
+          font.weight: 700
+        }
+
+        Repeater {
+          model: root.availableAlternateSinks()
+
+          delegate: Rectangle {
+            required property var modelData
+
+            Layout.fillWidth: true
+            radius: 14
+            color: root.isCurrentSink(modelData)
+              ? Qt.rgba(255 / 255, 0 / 255, 110 / 255, 0.1)
+              : rowHover.hovered
+                ? Qt.rgba(255 / 255, 255 / 255, 255 / 255, 0.05)
+                : Theme.glassAlt
+            border.width: 1
+            border.color: root.isCurrentSink(modelData)
+              ? Qt.rgba(255 / 255, 0 / 255, 110 / 255, 0.3)
+              : Theme.border
+            implicitHeight: 48
+
+            RowLayout {
+              anchors.fill: parent
+              anchors.margins: 12
+              spacing: 10
+
+              Text {
+                text: "󰕾"
+                color: Theme.fgMuted
+                font.family: Theme.monoFont
+                font.pixelSize: 15
+              }
+
+              Text {
+                Layout.fillWidth: true
+                text: root.sinkLabel(modelData)
+                color: Theme.fg
+                elide: Text.ElideRight
+                font.family: Theme.monoFont
+                font.pixelSize: 12
+                font.weight: 600
+              }
+            }
+
+            HoverHandler { id: rowHover }
+
+            MouseArea {
+              anchors.fill: parent
+              onClicked: Pipewire.preferredDefaultAudioSink = parent.modelData
+            }
+          }
+        }
+
+        Rectangle {
+          visible: root.availableAlternateSinks().length === 0
+          Layout.fillWidth: true
+          radius: 14
+          color: Theme.glassAlt
+          border.width: 1
+          border.color: Theme.border
+          implicitHeight: 44
+
+          Text {
+            anchors.centerIn: parent
+            text: "current output only"
+            color: Theme.fgMuted
+            font.family: Theme.monoFont
+            font.pixelSize: 12
+            font.weight: 700
+          }
         }
       }
 
@@ -164,12 +280,10 @@ PopupWindow {
       Connections {
         target: root.sink?.audio || null
 
-        function onVolumeChanged() {
-          if (!volumeSlider.pressed) volumeSlider.value = root.sink.audio.volume
+        function onMutedChanged() {
+          // Keep bindings reactive when mute state changes.
         }
       }
-
-      Component.onCompleted: volumeSlider.value = root.sink?.audio?.volume || 0
     }
   }
 }

--- a/modules/common/users/config-files/files/quickshell/Bar.qml
+++ b/modules/common/users/config-files/files/quickshell/Bar.qml
@@ -34,6 +34,7 @@ PanelWindow {
   }
 
   property string openPopup: ""
+  property bool audioPopupPinned: false
   property bool bluetoothPopupPinned: false
   property bool networkPopupPinned: false
   property string currentSubmap: "default"
@@ -47,6 +48,8 @@ PanelWindow {
   readonly property var activeToplevel: Hyprland.activeToplevel
   readonly property var primaryWorkspaceIds: [1, 2, 3]
   readonly property var networkDevices: Networking.devices.values
+  readonly property var audioSinks: Pipewire.nodes.values.filter(node => node?.audio && node.isSink && !node.isStream)
+  readonly property var sink: Pipewire.defaultAudioSink
   readonly property var bluetoothAdapter: Bluetooth.defaultAdapter
   readonly property var bluetoothDevices: Bluetooth.devices.values
   readonly property var connectedBluetoothDevices: bluetoothDevices.filter(device => device.connected)
@@ -66,6 +69,10 @@ PanelWindow {
     root.networkPopupPinned = !root.networkPopupPinned
   }
 
+  function toggleAudioPopup() {
+    root.audioPopupPinned = !root.audioPopupPinned
+  }
+
   function toggleBluetoothPopup() {
     root.bluetoothPopupPinned = !root.bluetoothPopupPinned
   }
@@ -78,12 +85,29 @@ PanelWindow {
     root.bluetoothPopupPinned = false
   }
 
+  function dismissAudioPopup() {
+    root.audioPopupPinned = false
+  }
+
   function openBluetoothSettings() {
     root.run("blueman-manager")
   }
 
   function run(command) {
     Hyprland.dispatch(`exec ${command}`)
+  }
+
+  function trackedAudioObjects() {
+    const objects = []
+
+    if (root.sink) objects.push(root.sink)
+
+    for (const node of root.audioSinks) {
+      if (!node) continue
+      if (objects.indexOf(node) === -1) objects.push(node)
+    }
+
+    return objects
   }
 
   function workspaceVisible(workspace) {
@@ -170,6 +194,10 @@ PanelWindow {
     running: true
     repeat: true
     onTriggered: root.preciseNow = new Date()
+  }
+
+  PwObjectTracker {
+    objects: root.trackedAudioObjects()
   }
 
   Rectangle {
@@ -319,8 +347,48 @@ PanelWindow {
     }
 
     Rectangle {
-      id: networkButton
+      id: audioButton
       anchors.right: clockButton.left
+      anchors.rightMargin: 8
+      anchors.verticalCenter: parent.verticalCenter
+      radius: 19
+      color: Qt.rgba(17 / 255, 24 / 255, 43 / 255, 0.86)
+      border.width: 1
+      border.color: audioHover.hovered ? Qt.rgba(255 / 255, 0 / 255, 110 / 255, 0.3) : Qt.rgba(72 / 255, 83 / 255, 141 / 255, 0.3)
+      implicitHeight: 42
+      implicitWidth: 60
+
+      Rectangle {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: parent.height / 2
+        radius: parent.radius
+        color: Qt.rgba(255 / 255, 255 / 255, 255 / 255, 0.024)
+      }
+
+      AudioChip {
+        anchors.centerIn: parent
+        volume: root.sink?.audio?.volume || 0
+        muted: root.sink?.audio?.muted || false
+        hovered: audioHover.hovered
+      }
+
+      HoverHandler { id: audioHover }
+
+      MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onClicked: mouse => {
+          if (mouse.button === Qt.RightButton) root.run("pavucontrol")
+          else root.toggleAudioPopup()
+        }
+      }
+    }
+
+    Rectangle {
+      id: networkButton
+      anchors.right: audioButton.left
       anchors.rightMargin: 8
       anchors.verticalCenter: parent.verticalCenter
       radius: 19
@@ -453,6 +521,19 @@ PanelWindow {
     uploadBps: networkStats.uploadBps
     peakDownloadBps: networkStats.peakDownloadBps
     peakUploadBps: networkStats.peakUploadBps
+  }
+
+  AudioPopup {
+    id: audioPopup
+    visible: root.audioPopupPinned || audioHover.hovered || popupHovered
+    anchorItem: audioButton
+    popupColor: popupBackgroundColor()
+    popupWidth: 340
+    sink: root.sink
+    sinks: root.audioSinks
+    runCommand: root.run
+    pinnedOpen: root.audioPopupPinned
+    dismissPopup: root.dismissAudioPopup
   }
 
   BluetoothPopup {

--- a/modules/common/users/config-files/files/quickshell/Sidebar.qml
+++ b/modules/common/users/config-files/files/quickshell/Sidebar.qml
@@ -1,6 +1,5 @@
 import Quickshell
 import Quickshell.Hyprland
-import Quickshell.Services.Pipewire
 import Quickshell.Services.UPower
 import QtQuick
 import QtQuick.Layouts
@@ -69,7 +68,6 @@ PanelWindow {
     bottom: ShellGeometry.sidebarBottom
   }
 
-  readonly property var sink: Pipewire.defaultAudioSink
   readonly property var battery: UPower.displayDevice
   readonly property int batteryPercent: Theme.batteryPercent(battery?.percentage)
   property var openPowerMenu: null
@@ -107,14 +105,6 @@ PanelWindow {
           radius: 16
           color: "transparent"
           border.width: 0
-        }
-
-        RailIconButton {
-          icon: sink?.audio?.muted ? "󰝟" : Theme.audioIcon(sink?.audio?.volume || 0, false, false)
-          accent: Theme.pink
-          active: !(sink?.audio?.muted ?? false)
-          onClicked: if (sink?.audio) sink.audio.muted = !sink.audio.muted
-          onRightClicked: root.run("pavucontrol")
         }
 
         RailIconButton {


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- add a dedicated Quickshell audio status chip to the top bar with a utility-first popup for mute, volume adjustment, and output switching
- move audio control from the sidebar into the same bar-level status cluster as bluetooth and network, and bind PipeWire sink objects correctly so the chip and popup reflect the real default output state
- simplify the audio popup to remove duplicated information and replace the unreliable drag slider with explicit step controls

## Validation
- `timeout 5s quickshell -vv -p "modules/common/users/config-files/files/quickshell/shell.qml"`
- `wpctl get-volume @DEFAULT_AUDIO_SINK@`