### PR TITLE
feat(shell): add battery status chip

### DIFF
--- a/modules/common/users/config-files/files/quickshell/Bar.qml
+++ b/modules/common/users/config-files/files/quickshell/Bar.qml
@@ -35,16 +35,17 @@ PanelWindow {
 
   property string openPopup: ""
   property bool audioPopupPinned: false
+  property bool batteryPopupPinned: false
   property bool bluetoothPopupPinned: false
   property bool networkPopupPinned: false
   property string currentSubmap: "default"
   property int chipHeight: 32
   property int popupWidth: 400
   property int compactPopupHeight: 276
-  property int batteryPopupHeight: 330
   property real pendingVolume: 0
+  readonly property var battery: UPower.displayDevice
+  readonly property var healthBattery: UPower.devices.values.find(device => device.isLaptopBattery) || null
   readonly property int batteryPercent: Theme.batteryPercent(root.battery?.percentage)
-  readonly property int batteryHealthPercent: Theme.batteryPercent(root.battery?.healthPercentage)
   readonly property var activeToplevel: Hyprland.activeToplevel
   readonly property var primaryWorkspaceIds: [1, 2, 3]
   readonly property var networkDevices: Networking.devices.values
@@ -73,6 +74,10 @@ PanelWindow {
     root.audioPopupPinned = !root.audioPopupPinned
   }
 
+  function toggleBatteryPopup() {
+    root.batteryPopupPinned = !root.batteryPopupPinned
+  }
+
   function toggleBluetoothPopup() {
     root.bluetoothPopupPinned = !root.bluetoothPopupPinned
   }
@@ -87,6 +92,10 @@ PanelWindow {
 
   function dismissAudioPopup() {
     root.audioPopupPinned = false
+  }
+
+  function dismissBatteryPopup() {
+    root.batteryPopupPinned = false
   }
 
   function openBluetoothSettings() {
@@ -347,8 +356,51 @@ PanelWindow {
     }
 
     Rectangle {
-      id: audioButton
+      id: batteryButton
       anchors.right: clockButton.left
+      anchors.rightMargin: 8
+      anchors.verticalCenter: parent.verticalCenter
+      radius: 19
+      color: Qt.rgba(17 / 255, 24 / 255, 43 / 255, 0.86)
+      border.width: 1
+      border.color: batteryHover.hovered
+        ? Qt.rgba(255 / 255, 234 / 255, 0 / 255, 0.3)
+        : Qt.rgba(72 / 255, 83 / 255, 141 / 255, 0.3)
+      implicitHeight: 42
+      implicitWidth: batteryChip.implicitWidth + 24
+
+      Rectangle {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: parent.height / 2
+        radius: parent.radius
+        color: Qt.rgba(255 / 255, 255 / 255, 255 / 255, 0.024)
+      }
+
+      BatteryChip {
+        id: batteryChip
+        anchors.centerIn: parent
+        batteryPercent: root.batteryPercent
+        charging: (root.battery?.timeToFull || 0) > 0
+        hovered: batteryHover.hovered
+      }
+
+      HoverHandler { id: batteryHover }
+
+      MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onClicked: mouse => {
+          if (mouse.button === Qt.RightButton) root.run("powerprofilesctl set balanced")
+          else root.toggleBatteryPopup()
+        }
+      }
+    }
+
+    Rectangle {
+      id: audioButton
+      anchors.right: batteryButton.left
       anchors.rightMargin: 8
       anchors.verticalCenter: parent.verticalCenter
       radius: 19
@@ -534,6 +586,20 @@ PanelWindow {
     runCommand: root.run
     pinnedOpen: root.audioPopupPinned
     dismissPopup: root.dismissAudioPopup
+  }
+
+  BatteryPopup {
+    id: batteryPopup
+    visible: root.batteryPopupPinned || batteryHover.hovered || popupHovered
+    anchorItem: batteryButton
+    popupColor: popupBackgroundColor()
+    popupWidth: 340
+    battery: root.battery
+    healthBattery: root.healthBattery
+    batteryPercent: root.batteryPercent
+    runCommand: root.run
+    pinnedOpen: root.batteryPopupPinned
+    dismissPopup: root.dismissBatteryPopup
   }
 
   BluetoothPopup {

--- a/modules/common/users/config-files/files/quickshell/BatteryChip.qml
+++ b/modules/common/users/config-files/files/quickshell/BatteryChip.qml
@@ -1,0 +1,63 @@
+import QtQuick
+import "."
+
+Item {
+  id: root
+
+  required property int batteryPercent
+  required property bool charging
+  required property bool hovered
+
+  function accentColor() {
+    if (root.charging) return Theme.cyan
+    if (root.batteryPercent <= 15) return Theme.pink
+    if (root.batteryPercent <= 35) return Theme.yellow
+    return Theme.blue
+  }
+
+  implicitWidth: 28
+  implicitHeight: 16
+
+  Rectangle {
+    id: shell
+    anchors.centerIn: parent
+    width: 22
+    height: 12
+    radius: 3
+    color: "transparent"
+    border.width: 1
+    border.color: Qt.tint(root.accentColor(), Qt.rgba(1, 1, 1, root.hovered ? 0.12 : 0))
+
+    Rectangle {
+      anchors.left: parent.left
+      anchors.leftMargin: 2
+      anchors.verticalCenter: parent.verticalCenter
+      width: Math.max(2, (parent.width - 4) * Math.max(0, Math.min(1, root.batteryPercent / 100)))
+      height: parent.height - 4
+      radius: 2
+      color: Qt.tint(root.accentColor(), Qt.rgba(1, 1, 1, root.hovered ? 0.1 : 0))
+      opacity: root.charging ? 0.95 : 0.88
+    }
+
+    Rectangle {
+      anchors.left: parent.right
+      anchors.leftMargin: 2
+      anchors.verticalCenter: parent.verticalCenter
+      width: 2
+      height: 6
+      radius: 1
+      color: Qt.tint(root.accentColor(), Qt.rgba(1, 1, 1, root.hovered ? 0.12 : 0))
+      opacity: 0.85
+    }
+
+    Text {
+      visible: root.charging
+      anchors.centerIn: parent
+      text: "󰂄"
+      color: Theme.bg
+      font.family: Theme.monoFont
+      font.pixelSize: 8
+      font.weight: 800
+    }
+  }
+}

--- a/modules/common/users/config-files/files/quickshell/BatteryPopup.qml
+++ b/modules/common/users/config-files/files/quickshell/BatteryPopup.qml
@@ -8,23 +8,77 @@ PopupWindow {
   required property var anchorItem
   required property color popupColor
   required property int popupWidth
-  required property int popupHeight
   required property var battery
+  required property var healthBattery
   required property int batteryPercent
-  required property int batteryHealthPercent
   required property var runCommand
-  property var openPowerMenu: null
+  required property bool pinnedOpen
+  required property var dismissPopup
+  property bool popupHovered: popupHover.hovered
 
   visible: false
-  grabFocus: true
+  grabFocus: pinnedOpen
   color: popupColor
   implicitWidth: popupWidth
-  implicitHeight: popupHeight
+  implicitHeight: 348
+
+  function batteryAccent() {
+    if (root.battery?.timeToFull > 0) return Theme.cyan
+    if (root.batteryPercent <= 15) return Theme.pink
+    if (root.batteryPercent <= 35) return Theme.yellow
+    return Theme.blue
+  }
+
+  function batteryStateLabel() {
+    if (root.battery?.timeToFull > 0) return "plugged in"
+    if (root.battery?.timeToEmpty > 0) return "on battery"
+    return "battery"
+  }
+
+  function changeRateWatts() {
+    return Math.abs(Number(root.battery?.changeRate || root.battery?.energyRate || 0))
+  }
+
+  function healthPercent() {
+    return Theme.batteryPercent(root.healthBattery?.healthPercentage)
+  }
+
+  function hasDrawInfo() {
+    return root.changeRateWatts() > 0
+  }
+
+  function hasHealthInfo() {
+    return !!root.healthBattery?.healthSupported && root.healthPercent() > 0
+  }
+
+  function timeMetricSeconds() {
+    return root.battery?.timeToFull > 0
+      ? Number(root.battery.timeToFull || 0)
+      : Number(root.battery?.timeToEmpty || 0)
+  }
+
+  function timeMetricLabel() {
+    return root.battery?.timeToFull > 0 ? "time to full" : "remaining"
+  }
+
+  function timeMetricText() {
+    return root.timeMetricSeconds() > 0 ? Theme.formatBatteryTime(root.timeMetricSeconds()) : "steady"
+  }
+
+  function metricBarRatio(kind) {
+    if (kind === "charge") return Math.max(0, Math.min(1, root.batteryPercent / 100))
+    if (kind === "time") return Math.max(0, Math.min(1, root.timeMetricSeconds() / (6 * 60 * 60)))
+    if (kind === "draw") return Math.max(0, Math.min(1, root.changeRateWatts() / 30))
+    return 0
+  }
+
+  onVisibleChanged: {
+    if (!visible && root.pinnedOpen) root.dismissPopup()
+  }
 
   anchor.item: anchorItem
-  anchor.edges: Edges.Bottom | Edges.Left
-  anchor.gravity: Edges.Bottom | Edges.Right
-  anchor.margins.top: 12
+  anchor.rect.x: anchorItem.width / 2 - width / 2
+  anchor.rect.y: anchorItem.height + 12
   anchor.adjustment: PopupAdjustment.All
 
   Rectangle {
@@ -34,34 +88,33 @@ PopupWindow {
     border.width: 1
     border.color: Theme.borderBright
 
-    Rectangle {
-      anchors.left: parent.left
-      anchors.right: parent.right
-      anchors.top: parent.top
-      height: 72
-      radius: parent.radius
-      color: Qt.rgba(122 / 255, 162 / 255, 247 / 255, 0.07)
-    }
+    HoverHandler { id: popupHover }
 
     ColumnLayout {
       anchors.fill: parent
       anchors.margins: 18
       spacing: 12
 
-      Text {
-        text: "Power"
-        color: Theme.yellow
-        font.family: Theme.monoFont
-        font.pixelSize: 16
-        font.weight: 800
-      }
+      RowLayout {
+        Layout.fillWidth: true
 
-      Text {
-        text: `${Theme.batteryIcon(root.batteryPercent, (root.battery?.timeToFull || 0) > 0)}  ${root.batteryPercent}%`
-        color: Theme.fg
-        font.family: Theme.monoFont
-        font.pixelSize: 28
-        font.weight: 700
+        Text {
+          text: "battery"
+          color: root.batteryAccent()
+          font.family: Theme.monoFont
+          font.pixelSize: 14
+          font.weight: 800
+        }
+
+        Item { Layout.fillWidth: true }
+
+        Text {
+          text: root.batteryStateLabel()
+          color: Theme.fgMuted
+          font.family: Theme.monoFont
+          font.pixelSize: 12
+          font.weight: 700
+        }
       }
 
       Rectangle {
@@ -70,7 +123,7 @@ PopupWindow {
         color: Theme.glassSoft
         border.width: 1
         border.color: Theme.border
-        implicitHeight: 72
+        implicitHeight: 84
 
         RowLayout {
           anchors.fill: parent
@@ -86,7 +139,7 @@ PopupWindow {
             Text {
               anchors.centerIn: parent
               text: Theme.batteryIcon(root.batteryPercent, (root.battery?.timeToFull || 0) > 0)
-              color: Theme.yellow
+              color: root.batteryAccent()
               font.family: Theme.monoFont
               font.pixelSize: 24
             }
@@ -94,14 +147,14 @@ PopupWindow {
 
           ColumnLayout {
             Layout.fillWidth: true
-            spacing: 2
+            spacing: 3
 
             Text {
-              text: root.battery?.timeToFull > 0 ? "Charging" : "Battery"
+              text: `${root.batteryPercent}%`
               color: Theme.fg
               font.family: Theme.monoFont
-              font.pixelSize: 13
-              font.weight: 700
+              font.pixelSize: 18
+              font.weight: 800
             }
 
             Text {
@@ -116,39 +169,70 @@ PopupWindow {
         }
       }
 
-      Text {
-        text: root.battery?.energyRate > 0 ? `Draw ${root.battery.energyRate.toFixed(1)}W` : "Energy rate unavailable"
-        color: Theme.fgMuted
-        font.family: Theme.monoFont
-        font.pixelSize: 13
-      }
+      Rectangle {
+        Layout.fillWidth: true
+        radius: 16
+        color: Theme.glassAlt
+        border.width: 1
+        border.color: Theme.border
+        implicitHeight: 190
 
-      Text {
-        text: root.battery?.healthSupported ? `Health ${root.batteryHealthPercent}%` : "Health unavailable"
-        color: Theme.fgMuted
-        font.family: Theme.monoFont
-        font.pixelSize: 13
-      }
+        ColumnLayout {
+          anchors.fill: parent
+          anchors.margins: 12
+          spacing: 10
 
-      RowLayout {
-        spacing: 10
+          Repeater {
+            model: [
+              { label: "charge", value: `${root.batteryPercent}%`, ratio: root.metricBarRatio("charge"), color: root.batteryAccent() },
+              { label: root.timeMetricLabel(), value: root.timeMetricText(), ratio: root.metricBarRatio("time"), color: Theme.blue },
+              { label: "draw", value: root.hasDrawInfo() ? `${root.changeRateWatts().toFixed(1)}W` : "steady", ratio: root.metricBarRatio("draw"), color: Theme.yellow },
+              { label: "health", value: root.hasHealthInfo() ? `${root.healthPercent()}%` : "n/a", ratio: root.hasHealthInfo() ? Math.max(0, Math.min(1, root.healthPercent() / 100)) : 0, color: Theme.purple }
+            ]
 
-        AccentButton {
-          text: "Power"
-          accent: Theme.yellow
-          onClicked: if (root.openPowerMenu) root.openPowerMenu()
-        }
+            delegate: ColumnLayout {
+              required property var modelData
 
-        AccentButton {
-          text: "Balanced"
-          accent: Theme.purple
-          onClicked: root.runCommand("powerprofilesctl set balanced")
-        }
+              Layout.fillWidth: true
+              spacing: 4
 
-        AccentButton {
-          text: "Saver"
-          accent: Theme.cyan
-          onClicked: root.runCommand("powerprofilesctl set power-saver")
+              RowLayout {
+                Layout.fillWidth: true
+
+                Text {
+                  text: modelData.label
+                  color: Theme.fgMuted
+                  font.family: Theme.monoFont
+                  font.pixelSize: 11
+                  font.weight: 700
+                }
+
+                Item { Layout.fillWidth: true }
+
+                Text {
+                  text: modelData.value
+                  color: Theme.fg
+                  font.family: Theme.monoFont
+                  font.pixelSize: 11
+                  font.weight: 700
+                }
+              }
+
+              Rectangle {
+                Layout.fillWidth: true
+                implicitHeight: 6
+                radius: 999
+                color: Qt.rgba(72 / 255, 83 / 255, 141 / 255, 0.22)
+
+                Rectangle {
+                  width: Math.max(3, parent.width * modelData.ratio)
+                  height: parent.height
+                  radius: parent.radius
+                  color: modelData.color
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/modules/common/users/config-files/files/quickshell/Sidebar.qml
+++ b/modules/common/users/config-files/files/quickshell/Sidebar.qml
@@ -1,6 +1,5 @@
 import Quickshell
 import Quickshell.Hyprland
-import Quickshell.Services.UPower
 import QtQuick
 import QtQuick.Layouts
 import "."
@@ -68,8 +67,6 @@ PanelWindow {
     bottom: ShellGeometry.sidebarBottom
   }
 
-  readonly property var battery: UPower.displayDevice
-  readonly property int batteryPercent: Theme.batteryPercent(battery?.percentage)
   property var openPowerMenu: null
 
   function run(command) {
@@ -94,33 +91,6 @@ PanelWindow {
       anchors.fill: parent
       anchors.margins: 8
       spacing: 8
-
-      ColumnLayout {
-        Layout.fillWidth: true
-        spacing: 6
-
-        Rectangle {
-          Layout.fillWidth: true
-          implicitHeight: 8
-          radius: 16
-          color: "transparent"
-          border.width: 0
-        }
-
-        RailIconButton {
-          icon: Theme.batteryIcon(batteryPercent, (battery?.timeToFull || 0) > 0)
-          accent: Theme.yellow
-          active: true
-          onClicked: if (root.openPowerMenu) root.openPowerMenu()
-          onRightClicked: root.run("powerprofilesctl set balanced")
-        }
-      }
-
-      Rectangle {
-        Layout.fillWidth: true
-        implicitHeight: 1
-        color: Qt.rgba(72 / 255, 83 / 255, 141 / 255, 0.16)
-      }
 
       Item { Layout.fillHeight: true }
 


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- add a compact battery status chip to the Quickshell top bar and remove the older sidebar-first battery control path
- redesign the battery popup to match the newer shell status surfaces, with cleaner battery state copy and a compact metrics panel for charge, forecast, draw, and health
- simplify the battery bar experience by using a visual battery shell in the bar and keeping exact numbers in the popup

## Validation
- `timeout 5s quickshell -vv -p "modules/common/users/config-files/files/quickshell/shell.qml"`
- `upower -i /org/freedesktop/UPower/devices/DisplayDevice`
- `upower -i /org/freedesktop/UPower/devices/battery_BAT1`