### PR TITLE
fix(opencode): harden draft PR creation guidance

### DIFF
--- a/docs/capabilities/ai-and-opencode.md
+++ b/docs/capabilities/ai-and-opencode.md
@@ -58,3 +58,58 @@ Examples include:
 
 - OpenCode is both a hosted service capability and a user environment capability.
 - Repo-level agent, command, and skill files are copied directly into user config directories during activation.
+
+## Runtime Paths
+
+The hosted OpenCode services on `ganymede` do not read the user-level `~/.config/opencode` trees.
+
+- Hosted `ryan` runtime: `/home/ryan/.local/share/opencode-service-ryan/config/opencode`
+- Hosted `odyssey` runtime: `/home/odyssey/.local/share/opencode-service-odyssey/config/opencode`
+- User-level config trees still exist at `~/.config/opencode` for interactive local use
+
+## Expected Global Commands And Skills
+
+The globally deployed OpenCode assets should include these command files:
+
+- `commit-branch`
+- `create-pr`
+- `draft-pr`
+- `grill-me`
+- `improve-codebase-architecture`
+- `prd-to-issues`
+- `review-pr`
+- `tdd`
+- `write-a-prd`
+
+The globally deployed skill set should include these base skills:
+
+- `frontend-design`
+- `git-commit-and-draft-pr`
+- `grill-me`
+- `improve-codebase-architecture`
+- `prd-to-issues`
+- `product-manager`
+- `review-pull-request`
+- `tdd`
+- `write-a-prd`
+
+## PR Safety Expectations
+
+Global OpenCode guidance should enforce these defaults for PR creation:
+
+- Load the `git-commit-and-draft-pr` skill for pull request creation requests
+- Default to draft mode unless the user explicitly asks for ready-for-review
+- Pass only clean rendered Markdown to `gh pr create`
+- Never include shell wrapper text like `$(cat <<'EOF'`, `EOF`, or trailing `)` in the PR body
+- Never post the PR body template as a GitHub comment unless the user explicitly asks for that comment
+
+## Verification
+
+After changing the OpenCode config in this repo and deploying `ganymede`, verify both hosted accounts against the runtime paths above.
+
+Check at minimum:
+
+- `AGENTS.md` contains the global PR safety rules
+- `commands/` contains both `draft-pr.md` and `create-pr.md`
+- `skills/git-commit-and-draft-pr/SKILL.md` contains the PR body sanity-check guidance
+- `opencode.json` still reflects the expected MCP set for `ryan` and `odyssey`

--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776701083,
-        "narHash": "sha256-7aq0E034894kd1iLuw40pqSqeTRrDUXLp1K2XoG+Q1w=",
+        "lastModified": 1776707615,
+        "narHash": "sha256-ZO5D2dgcG0E2aCufvEjELlEBzEr+SsK28xbSiJs+bjU=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "b20ca8a5c5be1d25d739c918b04950404254b7e1",
+        "rev": "298b85a8b397100f8e2a2ea25f92326344570b8a",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776699832,
-        "narHash": "sha256-IAI+2El+r37kgKHhONFyqOU/DEv546DJmwoEHi+swGc=",
+        "lastModified": 1776708911,
+        "narHash": "sha256-y1GVQEde10LorUv6g1OnsOJMemCdMykem0cCs4iiGWk=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "d2bad49ab5119bb81030bb7bdf579095da6e09b1",
+        "rev": "2e9bb29551123c5acd297455c10f1543ef186065",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776707615,
-        "narHash": "sha256-ZO5D2dgcG0E2aCufvEjELlEBzEr+SsK28xbSiJs+bjU=",
+        "lastModified": 1776701083,
+        "narHash": "sha256-7aq0E034894kd1iLuw40pqSqeTRrDUXLp1K2XoG+Q1w=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "298b85a8b397100f8e2a2ea25f92326344570b8a",
+        "rev": "b20ca8a5c5be1d25d739c918b04950404254b7e1",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776708911,
-        "narHash": "sha256-y1GVQEde10LorUv6g1OnsOJMemCdMykem0cCs4iiGWk=",
+        "lastModified": 1776699832,
+        "narHash": "sha256-IAI+2El+r37kgKHhONFyqOU/DEv546DJmwoEHi+swGc=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "2e9bb29551123c5acd297455c10f1543ef186065",
+        "rev": "d2bad49ab5119bb81030bb7bdf579095da6e09b1",
         "type": "github"
       },
       "original": {

--- a/modules/common/users/config-files/files/opencode/AGENTS.md
+++ b/modules/common/users/config-files/files/opencode/AGENTS.md
@@ -21,6 +21,14 @@
 - If both a base skill and a companion skill exist, use them together.
 - If a companion skill references repo docs, read those docs before making a plan.
 
+## Pull Requests
+
+- Any request to create or open a pull request must load and follow the `git-commit-and-draft-pr` skill.
+- Default to draft pull requests unless the user explicitly asks for ready-for-review.
+- Pass pull request bodies to `gh` as clean rendered Markdown only.
+- Never pass shell construction text such as `$(cat <<'EOF'`, `EOF`, or trailing `)` into a pull request title, body, or comment.
+- Never post the pull request body template as a GitHub comment unless the user explicitly asks for that comment.
+
 ## Project Command Execution
 
 - When a repository provides tooling through `flake.nix`, prefer running project commands via `nix develop` so they use the repo's pinned environment.

--- a/modules/common/users/config-files/files/opencode/commands/create-pr.md
+++ b/modules/common/users/config-files/files/opencode/commands/create-pr.md
@@ -1,5 +1,5 @@
 ---
-description: Create a signed conventional commit and open a draft PR using the git-commit-and-draft-pr skill
+description: Open a draft PR using the git-commit-and-draft-pr skill
 ---
 
 Load the `git-commit-and-draft-pr` skill and apply it to this request.

--- a/modules/common/users/config-files/files/opencode/skills/git-commit-and-draft-pr/SKILL.md
+++ b/modules/common/users/config-files/files/opencode/skills/git-commit-and-draft-pr/SKILL.md
@@ -82,10 +82,12 @@ Only do this when the user has explicitly asked to create a PR.
 2. Confirm the branch is based on the latest practical `origin/main`; if not, prefer rebasing before pushing.
 3. Push the current branch with `git push -u origin <branch>`.
 4. Use `gh pr create --draft`; draft mode is the default for this skill and should only be omitted if the user explicitly asks for a ready-for-review PR.
-5. Pass the PR body as rendered Markdown, not as shell source code.
-6. If you use a heredoc or temporary file to construct the body, ensure only the rendered Markdown is passed to `gh`; never include shell wrappers like `$(cat <<'EOF'`, `EOF`, or `)` in the PR text.
-7. Use the PR body template below unless the user asks for a different structure.
-8. Return the PR URL.
+5. Build the PR body as a plain Markdown string or write the Markdown to a temporary file and pass that rendered content to `gh`.
+6. If you use a heredoc or temporary file, treat it as an implementation detail only; never include shell wrappers like `$(cat <<'EOF'`, `EOF`, or `)` in the PR text.
+7. Before calling `gh pr create`, do a final sanity check that the title and body contain only the intended rendered Markdown and no shell syntax.
+8. Never post the PR body template as a GitHub comment unless the user explicitly asks for that comment.
+9. Use the PR body template below unless the user asks for a different structure.
+10. Return the PR URL.
 
 ## PR body template
 
@@ -111,3 +113,4 @@ Only do this when the user has explicitly asked to create a PR.
 - Prefer standard `git` workflows; do not assume GitButler or any alternate VCS tooling.
 - If signing or transport fails, prefer small SSH config diagnostics over inventing a parallel auth workflow.
 - Never paste shell construction syntax into a PR body; the PR body must be clean Markdown.
+- Never post the PR body template as a GitHub comment unless the user explicitly requests that exact comment.


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- add global OpenCode fallback rules so PR creation requests load the draft-safe workflow and never pass shell wrapper text into GitHub content
- add a discoverable `create-pr` command alias and document the expected hosted runtime files and verification checks on `ganymede`

## Validation
- `git diff origin/main...HEAD`
- Not run locally; config and docs changes only