### PR TITLE
feat(theme): align terminal stack with frame palette

### DIFF
--- a/modules/common/users/config-files/configs/ghostty.nix
+++ b/modules/common/users/config-files/configs/ghostty.nix
@@ -5,7 +5,7 @@
 }: let
   isDarwin = pkgs.stdenv.isDarwin;
   defaultConfig = {
-    theme = "Synthwave";
+    theme = "tokyo-cyber";
     font-family = "JetBrainsMono Nerd Font Mono";
     font-size = 14;
     background-opacity = 1.0;

--- a/modules/common/users/config-files/configs/opencode.nix
+++ b/modules/common/users/config-files/configs/opencode.nix
@@ -7,6 +7,7 @@
   isDarwin = pkgs.stdenv.isDarwin;
   opencodeCommandsPath = ../files/opencode/commands;
   opencodeSkillsPath = ../files/opencode/skills;
+  opencodeThemesPath = ../files/opencode/themes;
 
   mkOpencodeConfig = {
     user,
@@ -86,7 +87,7 @@
 
   mkOpencodeTuiConfig = {
     "$schema" = "https://opencode.ai/tui.json";
-    theme = "opencode";
+    theme = "tokyo-cyber";
     scroll_acceleration = {
       enabled = true;
     };
@@ -110,8 +111,8 @@ in {
       [ -L "${homeDir}/.config/opencode/tui.json" ] && rm "${homeDir}/.config/opencode/tui.json"
       [ -L "${homeDir}/.config/opencode/tui.jsonc" ] && rm "${homeDir}/.config/opencode/tui.jsonc"
       rm -rf "${homeDir}/.config/opencode/secrets"
-      rm -rf "${homeDir}/.config/opencode/commands" "${homeDir}/.config/opencode/skills"
-      mkdir -p "${homeDir}/.config/opencode/commands" "${homeDir}/.config/opencode/skills" "${homeDir}/.config/opencode/secrets"
+      rm -rf "${homeDir}/.config/opencode/commands" "${homeDir}/.config/opencode/skills" "${homeDir}/.config/opencode/themes"
+      mkdir -p "${homeDir}/.config/opencode/commands" "${homeDir}/.config/opencode/skills" "${homeDir}/.config/opencode/themes" "${homeDir}/.config/opencode/secrets"
 
       if [ -f "/var/lib/opnix/secrets/kagi-api-key" ]; then
         cp "/var/lib/opnix/secrets/kagi-api-key" "${homeDir}/.config/opencode/secrets/kagi-api-key"
@@ -134,5 +135,6 @@ in {
       cp ${opencodeAgentsPath} "${homeDir}/.config/opencode/AGENTS.md"
       cp -R ${opencodeCommandsPath}/. "${homeDir}/.config/opencode/commands"
       cp -R ${opencodeSkillsPath}/. "${homeDir}/.config/opencode/skills"
+      cp -R ${opencodeThemesPath}/. "${homeDir}/.config/opencode/themes"
     '';
 }

--- a/modules/common/users/config-files/files/ghostty/themes/tokyo-cyber
+++ b/modules/common/users/config-files/files/ghostty/themes/tokyo-cyber
@@ -1,0 +1,23 @@
+# Frame desktop palette for Ghostty.
+palette = 0=#20284a
+palette = 1=#ff006e
+palette = 2=#9ece6a
+palette = 3=#ffea00
+palette = 4=#7aa2f7
+palette = 5=#9d4edd
+palette = 6=#00f0ff
+palette = 7=#d9def2
+palette = 8=#6a78aa
+palette = 9=#ff4d9d
+palette = 10=#b7f27d
+palette = 11=#fff27a
+palette = 12=#9ab8ff
+palette = 13=#c792ea
+palette = 14=#7df9ff
+palette = 15=#f2f5ff
+background = #1a2140
+foreground = #d9def2
+cursor-color = #00f0ff
+cursor-text = #1a2140
+selection-background = #6a78aa
+selection-foreground = #f2f5ff

--- a/modules/common/users/config-files/files/opencode/themes/tokyo-cyber.json
+++ b/modules/common/users/config-files/files/opencode/themes/tokyo-cyber.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "https://opencode.ai/theme.json",
+  "defs": {
+    "bg": "#1a2140",
+    "panel": "#20284a",
+    "element": "#252e55",
+    "border": "#6a78aa",
+    "borderActive": "#7aa2f7",
+    "text": "#d9def2",
+    "textMuted": "#8b93b8",
+    "pink": "#ff006e",
+    "cyan": "#00f0ff",
+    "purple": "#9d4edd",
+    "yellow": "#ffea00",
+    "blue": "#7aa2f7",
+    "green": "#9ece6a",
+    "red": "#f7768e",
+    "white": "#f2f5ff"
+  },
+  "theme": {
+    "primary": {
+      "dark": "cyan",
+      "light": "blue"
+    },
+    "secondary": {
+      "dark": "purple",
+      "light": "purple"
+    },
+    "accent": {
+      "dark": "pink",
+      "light": "pink"
+    },
+    "error": {
+      "dark": "red",
+      "light": "red"
+    },
+    "warning": {
+      "dark": "yellow",
+      "light": "yellow"
+    },
+    "success": {
+      "dark": "green",
+      "light": "green"
+    },
+    "info": {
+      "dark": "blue",
+      "light": "blue"
+    },
+    "text": {
+      "dark": "text",
+      "light": "bg"
+    },
+    "textMuted": {
+      "dark": "textMuted",
+      "light": "border"
+    },
+    "background": {
+      "dark": "bg",
+      "light": "white"
+    },
+    "backgroundPanel": {
+      "dark": "panel",
+      "light": "text"
+    },
+    "backgroundElement": {
+      "dark": "element",
+      "light": "text"
+    },
+    "border": {
+      "dark": "border",
+      "light": "textMuted"
+    },
+    "borderActive": {
+      "dark": "borderActive",
+      "light": "blue"
+    },
+    "borderSubtle": {
+      "dark": "panel",
+      "light": "text"
+    },
+    "diffAdded": {
+      "dark": "green",
+      "light": "green"
+    },
+    "diffRemoved": {
+      "dark": "pink",
+      "light": "pink"
+    },
+    "diffContext": {
+      "dark": "textMuted",
+      "light": "border"
+    },
+    "diffHunkHeader": {
+      "dark": "blue",
+      "light": "blue"
+    },
+    "diffHighlightAdded": {
+      "dark": "green",
+      "light": "green"
+    },
+    "diffHighlightRemoved": {
+      "dark": "pink",
+      "light": "pink"
+    },
+    "diffAddedBg": {
+      "dark": "panel",
+      "light": "white"
+    },
+    "diffRemovedBg": {
+      "dark": "panel",
+      "light": "white"
+    },
+    "diffContextBg": {
+      "dark": "bg",
+      "light": "text"
+    },
+    "diffLineNumber": {
+      "dark": "border",
+      "light": "textMuted"
+    },
+    "diffAddedLineNumberBg": {
+      "dark": "panel",
+      "light": "white"
+    },
+    "diffRemovedLineNumberBg": {
+      "dark": "panel",
+      "light": "white"
+    },
+    "markdownText": {
+      "dark": "text",
+      "light": "bg"
+    },
+    "markdownHeading": {
+      "dark": "cyan",
+      "light": "blue"
+    },
+    "markdownLink": {
+      "dark": "blue",
+      "light": "blue"
+    },
+    "markdownLinkText": {
+      "dark": "pink",
+      "light": "pink"
+    },
+    "markdownCode": {
+      "dark": "green",
+      "light": "green"
+    },
+    "markdownBlockQuote": {
+      "dark": "textMuted",
+      "light": "border"
+    },
+    "markdownEmph": {
+      "dark": "purple",
+      "light": "purple"
+    },
+    "markdownStrong": {
+      "dark": "yellow",
+      "light": "yellow"
+    },
+    "markdownHorizontalRule": {
+      "dark": "border",
+      "light": "textMuted"
+    },
+    "markdownListItem": {
+      "dark": "cyan",
+      "light": "blue"
+    },
+    "markdownListEnumeration": {
+      "dark": "pink",
+      "light": "pink"
+    },
+    "markdownImage": {
+      "dark": "blue",
+      "light": "blue"
+    },
+    "markdownImageText": {
+      "dark": "purple",
+      "light": "purple"
+    },
+    "markdownCodeBlock": {
+      "dark": "text",
+      "light": "bg"
+    },
+    "syntaxComment": {
+      "dark": "textMuted",
+      "light": "border"
+    },
+    "syntaxKeyword": {
+      "dark": "pink",
+      "light": "pink"
+    },
+    "syntaxFunction": {
+      "dark": "cyan",
+      "light": "blue"
+    },
+    "syntaxVariable": {
+      "dark": "text",
+      "light": "bg"
+    },
+    "syntaxString": {
+      "dark": "green",
+      "light": "green"
+    },
+    "syntaxNumber": {
+      "dark": "yellow",
+      "light": "yellow"
+    },
+    "syntaxType": {
+      "dark": "purple",
+      "light": "purple"
+    },
+    "syntaxOperator": {
+      "dark": "blue",
+      "light": "blue"
+    },
+    "syntaxPunctuation": {
+      "dark": "textMuted",
+      "light": "border"
+    }
+  }
+}

--- a/modules/common/users/config-files/files/zellij.kdl
+++ b/modules/common/users/config-files/files/zellij.kdl
@@ -1,9 +1,9 @@
 // Balanced TokyoNight-cyberpunk palette shared with the desktop
 themes {
     tokyo-cyber {
-        fg 205 214 244
-        bg 10 14 39
-        black 26 27 38
+        fg 217 222 242
+        bg 26 33 64
+        black 32 40 74
         red 255 0 110
         green 158 206 106
         yellow 255 234 0
@@ -11,7 +11,7 @@ themes {
         magenta 157 78 221
         orange 255 159 28
         cyan 0 240 255
-        white 224 224 224
+        white 217 222 242
     }
 }
 

--- a/modules/nixos/opencode.nix
+++ b/modules/nixos/opencode.nix
@@ -13,6 +13,7 @@
   opencodeAgentsPath = "${opencodeAssets}/AGENTS.md";
   opencodeCommandsPath = "${opencodeAssets}/commands";
   opencodeSkillsPath = "${opencodeAssets}/skills";
+  opencodeThemesPath = "${opencodeAssets}/themes";
 
   mkInstanceData = name: instance: let
     capitalizedName = lib.toUpper (builtins.substring 0 1 name) + builtins.substring 1 ((builtins.stringLength name) - 1) name;
@@ -115,7 +116,7 @@
 
     opencodeTuiConfig = {
       "$schema" = "https://opencode.ai/tui.json";
-      theme = "opencode";
+      theme = "tokyo-cyber";
       scroll_acceleration = {
         enabled = true;
       };
@@ -198,11 +199,13 @@
       "$cp_bin" ${lib.escapeShellArg gitConfigFile} ${lib.escapeShellArg "${stateRoot}/.gitconfig"}
       "$cp_bin" ${lib.escapeShellArg sshConfig} ${lib.escapeShellArg sshConfigFile}
 
-      "$rm_bin" -rf ${lib.escapeShellArg "${opencodeConfigDir}/commands"} ${lib.escapeShellArg "${opencodeConfigDir}/skills"}
+      "$rm_bin" -rf ${lib.escapeShellArg "${opencodeConfigDir}/commands"} ${lib.escapeShellArg "${opencodeConfigDir}/skills"} ${lib.escapeShellArg "${opencodeConfigDir}/themes"}
       "$install_bin" -d -m 0750 -o ${instance.user} -g ${instance.group} ${lib.escapeShellArg "${opencodeConfigDir}/commands"}
       "$install_bin" -d -m 0750 -o ${instance.user} -g ${instance.group} ${lib.escapeShellArg "${opencodeConfigDir}/skills"}
+      "$install_bin" -d -m 0750 -o ${instance.user} -g ${instance.group} ${lib.escapeShellArg "${opencodeConfigDir}/themes"}
       "$cp_bin" -R ${lib.escapeShellArg "${opencodeCommandsPath}/."} ${lib.escapeShellArg "${opencodeConfigDir}/commands"}
       "$cp_bin" -R ${lib.escapeShellArg "${opencodeSkillsPath}/."} ${lib.escapeShellArg "${opencodeConfigDir}/skills"}
+      "$cp_bin" -R ${lib.escapeShellArg "${opencodeThemesPath}/."} ${lib.escapeShellArg "${opencodeConfigDir}/themes"}
 
       ${lib.optionalString instance.enableServerAuth ''
         if [ -f ${lib.escapeShellArg serverPasswordPath} ]; then


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- replace the generic Ghostty and OpenCode defaults with repo-managed tokyo-cyber themes that match frame's synthwave palette
- tune Zellij and terminal background surfaces toward a muted indigo base so the terminal stack reads consistently instead of falling back to near-black
