### PR TITLE
fix(nixos): unblock remote deploys and refresh opencode defaults

### DIFF
--- a/flake/nixos.nix
+++ b/flake/nixos.nix
@@ -8,7 +8,7 @@
       config = {
         allowUnfree = true;
         permittedInsecurePackages = [
-          "ventoy-1.1.10"
+          "ventoy-1.1.12"
         ];
       };
       overlays = import ../modules/overlays;

--- a/modules/common/users/config-files/configs/opencode.nix
+++ b/modules/common/users/config-files/configs/opencode.nix
@@ -18,7 +18,7 @@
     pencilEnabled = isDarwin && isRyan && !isCompanyProfile;
   in {
     "$schema" = "https://opencode.ai/config.json";
-    model = "openai/gpt-5.4";
+    model = "openai/gpt-5.5";
     small_model = "openai/gpt-5.3-codex-spark";
     autoupdate = true;
     permission = {

--- a/modules/common/users/config-files/files/nushell/autoload/nix.nu
+++ b/modules/common/users/config-files/files/nushell/autoload/nix.nu
@@ -15,7 +15,7 @@ def nr [] {
 def nrr [host?: string  # Optional remote host name
 ] {
     let existing_nix_config = ($env.NIX_CONFIG | default "" | str trim -r -c "\n")
-    let nrr_nix_config = ($existing_nix_config + "\nallow-dirty = true\nallow-dirty-locks = true\nwarn-dirty = false\nwrite-lock-file = false\n")
+    let nrr_nix_config = ($existing_nix_config + "\nallow-dirty = true\nallow-dirty-locks = true\nwarn-dirty = false\n")
 
     if ($host == null) {
         print "No host specified, building remote hosts (ganymede, callisto)..."

--- a/modules/nixos/caddy.nix
+++ b/modules/nixos/caddy.nix
@@ -334,7 +334,7 @@ in {
       enable = true;
       package = lib.mkIf cfg.internal.enable (pkgs.caddy.withPlugins {
         plugins = ["github.com/caddy-dns/cloudflare@v0.2.4"];
-        hash = "sha256-Olz4W84Kiyldy+JtbIicVCL7dAYl4zq+2rxEOUTObxA=";
+        hash = "sha256-J0HWjCPoOoARAxDpG2bS9c0x5Wv4Q23qWZbTjd8nW84=";
       });
       virtualHosts = generateVirtualHosts;
     };

--- a/modules/nixos/core.nix
+++ b/modules/nixos/core.nix
@@ -15,6 +15,13 @@
   };
 
   config = lib.mkIf config.host.nix.enableOptimalCaching {
+    services.dbus.implementation = lib.mkDefault "dbus";
+
+    systemd.user.services.dbus = {
+      startLimitBurst = 5;
+      startLimitIntervalSec = 30;
+    };
+
     nix = {
       package = pkgs.nixVersions.stable;
       extraOptions = ''

--- a/modules/nixos/fingerprint-reader.nix
+++ b/modules/nixos/fingerprint-reader.nix
@@ -1,13 +1,21 @@
-{pkgs, ...}: {
-  # Finger Print Reader
-  services.fprintd.enable = true;
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  isDesktop = config.host.roles.desktop;
+in {
+  config = lib.mkIf isDesktop {
+    services.fprintd.enable = true;
 
-  services.fprintd.tod = {
-    enable = true;
-    driver = pkgs.libfprint-2-tod1-goodix;
+    services.fprintd.tod = {
+      enable = true;
+      driver = pkgs.libfprint-2-tod1-goodix;
+    };
+
+    environment.systemPackages = with pkgs; [
+      fprintd
+    ];
   };
-
-  environment.systemPackages = with pkgs; [
-    fprintd
-  ];
 }

--- a/modules/nixos/opencode.nix
+++ b/modules/nixos/opencode.nix
@@ -585,7 +585,7 @@ in {
 
           model = lib.mkOption {
             type = lib.types.str;
-            default = "openai/gpt-5.4";
+            default = "openai/gpt-5.5";
             description = "Primary model for this OpenCode instance.";
           };
 

--- a/modules/nixos/pueue.nix
+++ b/modules/nixos/pueue.nix
@@ -2,6 +2,8 @@
   systemd.user.services.pueued = {
     description = "Pueue daemon";
     wantedBy = ["default.target"];
+    startLimitBurst = 5;
+    startLimitIntervalSec = 30;
     serviceConfig = {
       Type = "simple";
       ExecStart = "${pkgs.pueue}/bin/pueued";

--- a/modules/nixos/security.nix
+++ b/modules/nixos/security.nix
@@ -26,11 +26,11 @@ in {
   # Ensure we don't accidentally add sudo to systemPackages
   # This would bypass the setuid wrapper
   nixpkgs.config.permittedInsecurePackages = [
-    "ventoy-1.1.10"
+    "ventoy-1.1.12"
   ];
 
   services.yubikey-agent.enable = lib.mkIf isDesktop true;
-  programs.yubikey-touch-detector.enable = true;
+  programs.yubikey-touch-detector.enable = lib.mkIf isDesktop true;
 
   security.pam = {
     services = {

--- a/modules/nixos/session.nix
+++ b/modules/nixos/session.nix
@@ -50,6 +50,8 @@
     systemd.user.services.hyprpolkitagent = {
       description = "Hyprland polkit agent";
       wantedBy = ["default.target"];
+      startLimitBurst = 5;
+      startLimitIntervalSec = 30;
       serviceConfig = {
         ExecStart = "${pkgs.hyprpolkitagent}/libexec/hyprpolkitagent";
         Restart = "on-failure";

--- a/modules/nixos/ventoy-web.nix
+++ b/modules/nixos/ventoy-web.nix
@@ -26,7 +26,7 @@ in {
   config = mkIf cfg.enable {
     # Allow insecure Ventoy package (marked as insecure in nixpkgs)
     nixpkgs.config.permittedInsecurePackages = [
-      "ventoy-1.1.10"
+      "ventoy-1.1.12"
     ];
 
     # Ensure Ventoy package is available


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- unblock `callisto` and `ganymede` deploys by fixing stale Ventoy/Caddy inputs and scoping desktop-only user services away from remote hosts
- pin D-Bus and user-service rate-limit defaults to avoid activation and `user-units` evaluation failures on current nixpkgs
- update the default OpenCode model from `openai/gpt-5.4` to `openai/gpt-5.5` in both generated config and module defaults