### PR TITLE
feat: [MMI-354] package combined server

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,16 +74,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1774235677,
-        "narHash": "sha256-0ryNYmzDAeRlrzPTAgmzGH/Cgc8iv/LBN6jWGUANvIk=",
+        "lastModified": 1776478798,
+        "narHash": "sha256-ERStG27tf83VbCfYMxtDSs+sa8FUMJ/3jSu/QfX9rKE=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "894a3d23ac0c8aaf561b9874b528b9cb2e839201",
+        "rev": "3aae056b8d072624255bc8fd27febb7f327b2265",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.1",
+        "ref": "5.1.7",
         "repo": "brew",
         "type": "github"
       }
@@ -95,11 +95,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776613567,
-        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
+        "lastModified": 1777713215,
+        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
+        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1777678872,
+        "narHash": "sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT+IPhcsukVbgk=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "5250617bffd85403b14dbf43c3870e7f255d2c16",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776878074,
-        "narHash": "sha256-zZSkhN/fgztV+mQDRd/CXoLevd6Ymk3bkeoroGd50nA=",
+        "lastModified": 1777812737,
+        "narHash": "sha256-FxLu3aPVwH6tr82ObE8gCO21UOD3Szn5BGLuIaLrjZM=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "f546cc201be85fe31e484f7597bb304e5c7f2524",
+        "rev": "10a657773c0a80e86ff2d37a7f03242f5e181ed7",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776879187,
-        "narHash": "sha256-8/tbjet6Q8NduNdkaZGxRMSsLND/9ysFrpivoGs8vy8=",
+        "lastModified": 1777813147,
+        "narHash": "sha256-quttgHzTOmZUt14x8+cYgaDvSgcIlwLlvNu3KjGB7DE=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "9ee102d44d69ba2c000d9e436a4d8f546c107566",
+        "rev": "40f6e59ddfac46abb4eaf3784f3d924c05b9d440",
         "type": "github"
       },
       "original": {
@@ -289,11 +289,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775037210,
-        "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
+        "lastModified": 1777780666,
+        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
+        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1774720267,
-        "narHash": "sha256-YYftFe8jyfpQI649yfr0E+dqEXE2jznZNcYvy/lKV1U=",
+        "lastModified": 1777250621,
+        "narHash": "sha256-WynkkG0hdZ5niYPJUbVg7oMfu8MVwGGzKZ6lKmfa+O8=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "a7760a3a83f7609f742861afb5732210fdc437ed",
+        "rev": "aeb2069920742d0d6570089e8b3b8620050bacf2",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1776564050,
-        "narHash": "sha256-01CvP7g0lwWuB1ruUKUy/xZqorQYKaTd4iPdCAoToFk=",
+        "lastModified": 1777774190,
+        "narHash": "sha256-o/87U1M3Kvk6TsMLFu9PSdV8Qtz8q44B1tIhewR6vj8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "927c9af2765fead764f1a6b9557feef2a40201f5",
+        "rev": "9face6a87d97f20068bcd69de5eac3de0049c3df",
         "type": "github"
       },
       "original": {
@@ -522,11 +522,11 @@
         "pion-webrtc": "pion-webrtc"
       },
       "locked": {
-        "lastModified": 1776636929,
-        "narHash": "sha256-3v1mQZa9k8nO8/KMZrQGYi1V5Y3tra1npwAap/iZ2+M=",
+        "lastModified": 1777798222,
+        "narHash": "sha256-RTVIv8oLvBvlHgmOg8OvfUZ+q0trLRmgefxpx1/Qe5I=",
         "owner": "spacebarchat",
         "repo": "server",
-        "rev": "5cb017ba1cea7ed61afc0732eb485137fe6b7744",
+        "rev": "1eb2d71854c8a44ee525fb4872aae6bf074c9efd",
         "type": "github"
       },
       "original": {

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -3,6 +3,8 @@
   lib,
   ...
 }: {
+  nixpkgs.overlays = import ../overlays;
+
   imports = [
     ../common
 

--- a/modules/overlays/default.nix
+++ b/modules/overlays/default.nix
@@ -1,4 +1,8 @@
 [
+  (_final: prev: {
+    netbird-server = prev.callPackage ./packages/netbird-server.nix {};
+  })
+
   # Disable checks for fish shell
   (_final: prev: {
     fish = prev.fish.overrideAttrs (_oldAttrs: {

--- a/modules/overlays/packages/netbird-server.nix
+++ b/modules/overlays/packages/netbird-server.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "netbird-server";
+  version = "0.70.4";
+
+  src = fetchFromGitHub {
+    owner = "netbirdio";
+    repo = "netbird";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tfScscRllUlV1V6D66rfT6JEsReDQfVGryVzNebm0vg=";
+  };
+
+  vendorHash = "sha256-IRV1GxdUKgan0GwmBg9acpl7plW01CtEO2FrKrlDdeE=";
+
+  subPackages = ["combined"];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/netbirdio/netbird/version.version=${finalAttrs.version}"
+    "-X main.builtBy=nix"
+  ];
+
+  # Upstream's Go tests require network access, matching nixpkgs' NetBird packages.
+  doCheck = false;
+
+  postInstall = ''
+    mv $out/bin/combined $out/bin/netbird-server
+  '';
+
+  meta = {
+    description = "Combined NetBird self-hosted server";
+    homepage = "https://netbird.io";
+    changelog = "https://github.com/netbirdio/netbird/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      nazarewk
+      saturn745
+      loc
+    ];
+    mainProgram = "netbird-server";
+  };
+})


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Linear
- MMI-354

## Summary
- Add a repo-local native `netbird-server` derivation for upstream NetBird v0.70.4.
- Expose the package through the shared overlay and NixOS module package sets so callisto can evaluate it.
- Verified formatting, flake checks, and a Linux build/run of `netbird-server --help` on callisto.

## Validation
- `nix develop -c alejandra modules/overlays/default.nix modules/overlays/packages/netbird-server.nix modules/nixos/default.nix`
- `nix flake check --show-trace`
- Built `nixosConfigurations.callisto.pkgs.netbird-server` in callisto remote store
- Ran `/nix/store/c7xfyqrzmj52wzc0i4pyx7dl5xfk27qm-netbird-server-0.70.4/bin/netbird-server --help` on callisto