### PR TITLE
feat: expose NetBird through Caddy

### DIFF
--- a/hosts/callisto/configuration.nix
+++ b/hosts/callisto/configuration.nix
@@ -283,6 +283,70 @@ in {
     storeEncryptionKeySecretRef = "op://Homelab/NetBird Store Encryption Key/password";
   };
 
+  services.caddy.virtualHosts."netbird.rgbr.ink" = {
+    extraConfig = let
+      certPath = config.services.onepassword-secrets.secretPaths.sslCloudflareCert;
+      keyPath = config.services.onepassword-secrets.secretPaths.sslCloudflareKey;
+    in ''
+      tls ${certPath} ${keyPath}
+
+      log {
+        output file /var/log/caddy/netbird.log
+        format console
+        level INFO
+      }
+
+      header /OidcTrustedDomains.js Cache-Control "no-store"
+
+      @grpc {
+        protocol grpc
+      }
+      handle @grpc {
+        reverse_proxy h2c://127.0.0.1:8081 {
+          header_up Host {host}
+          header_up X-Real-IP {remote_host}
+          header_up X-Forwarded-For {remote_host}
+          header_up X-Forwarded-Proto {scheme}
+          header_up X-Forwarded-Host {host}
+          health_timeout 5s
+        }
+      }
+
+      @netbirdServer {
+        path /api /api/* /oauth2 /oauth2/* /relay /relay* /ws-proxy /ws-proxy/* /.well-known /.well-known/*
+      }
+      handle @netbirdServer {
+        reverse_proxy 127.0.0.1:8081 {
+          transport http {
+            keepalive 2m
+            versions 1.1 2
+          }
+          header_up Host {host}
+          header_up X-Real-IP {remote_host}
+          header_up X-Forwarded-For {remote_host}
+          header_up X-Forwarded-Proto {scheme}
+          header_up X-Forwarded-Host {host}
+          health_timeout 5s
+        }
+      }
+
+      handle {
+        reverse_proxy 127.0.0.1:8080 {
+          transport http {
+            keepalive 2m
+            versions 1.1 2
+          }
+          header_up Host {upstream_hostport}
+          header_up X-Real-IP {remote_host}
+          header_up X-Forwarded-For {remote_host}
+          header_up X-Forwarded-Proto {scheme}
+          header_up X-Forwarded-Host {host}
+          health_timeout 5s
+        }
+      }
+    '';
+  };
+
   # Spacebar reverse proxy: multi-backend routing (API, CDN, Gateway)
   # configured directly via services.caddy.virtualHosts since it needs
   # path/protocol-based routing across multiple backend ports


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- Adds a dedicated `netbird.rgbr.ink` Caddy virtual host on callisto using the existing Cloudflare Origin certificate secrets.
- Routes NetBird gRPC to the combined server over h2c, routes API/OIDC/relay paths to the combined server, and serves the dashboard through the local dashboard listener.
- Marks `OidcTrustedDomains.js` as `no-store` so Cloudflare does not cache stale dashboard auth-domain config.

## Validation
- `nix develop -c alejandra --check .`
- `nix develop -c deadnix --fail .`
- `nix flake check --show-trace`
- Remote callisto system build succeeded.
- `nix develop -c colmena apply --impure --on callisto`
- Verified public dashboard loads at `https://netbird.rgbr.ink/` and first-admin setup completed.
- Verified public `/api/instance` returns NetBird instance state.
- Verified public OIDC discovery returns issuer `https://netbird.rgbr.ink/oauth2`.
- Verified public gRPC reaches NetBird; `grpcurl list` now fails with reflection disabled instead of Cloudflare `403`.
- Verified first peer `dot.local` enrolled and appears online in the dashboard.
