### PR TITLE
Configure NetBird to use Cloudflare public STUN

### DIFF
--- a/modules/nixos/netbird-combined.nix
+++ b/modules/nixos/netbird-combined.nix
@@ -14,10 +14,11 @@
   authIssuer = "https://${cfg.domain}/oauth2";
   dashboard = cfg.dashboard;
   dashboardOrigin = "https://${cfg.domain}";
-  stunPortsYaml =
-    if cfg.stun.enable
-    then "stunPorts:\n    - ${toString cfg.stun.port}"
-    else "stunPorts: []";
+  stunPortsYaml = "stunPorts: []";
+  stunsYaml =
+    if cfg.stun.enable && cfg.stun.uris != []
+    then "stuns:\n${lib.concatMapStringsSep "\n" (uri: "    - uri: ${uri}\n      proto: udp") cfg.stun.uris}"
+    else "stuns: []";
   configuredDashboard = pkgs.runCommand "netbird-dashboard-configured" {nativeBuildInputs = [pkgs.gettext];} ''
     cp -R ${dashboard.package} $out
     chmod -R u+w $out
@@ -107,12 +108,12 @@ in {
     };
 
     stun = {
-      enable = lib.mkEnableOption "the local NetBird STUN listener" // {default = true;};
+      enable = lib.mkEnableOption "external NetBird STUN discovery" // {default = true;};
 
-      port = lib.mkOption {
-        type = lib.types.port;
-        default = 3478;
-        description = "UDP port for the local NetBird STUN listener.";
+      uris = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = ["stun:stun.cloudflare.com:3478"];
+        description = "External STUN URIs advertised to NetBird clients.";
       };
     };
 
@@ -262,8 +263,6 @@ in {
       "d ${toString cfg.dataDir} 0750 netbird netbird -"
     ];
 
-    networking.firewall.allowedUDPPorts = lib.optional cfg.stun.enable cfg.stun.port;
-
     systemd.services.netbird-combined = {
       description = "Combined NetBird self-hosted server";
       wantedBy = ["multi-user.target"];
@@ -307,6 +306,7 @@ in {
           dataDir: ${toString cfg.dataDir}
           authSecret: $auth_secret
           ${stunPortsYaml}
+          ${stunsYaml}
           disableAnonymousMetrics: ${lib.boolToString cfg.disableAnonymousMetrics}
           disableGeoliteUpdate: ${lib.boolToString cfg.disableGeoliteUpdate}
           store:


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- Configures the NetBird combined module to advertise Cloudflare public STUN instead of running local STUN on callisto.
- Removes the local UDP 3478 firewall opening by rendering `stunPorts: []` and external `server.stuns` entries.

## Verification
- `nix develop -c alejandra .`
- `nix develop -c alejandra --check .`
- `nix develop -c deadnix --fail .`
- `nix flake check --show-trace`
- Remote callisto build succeeded.
- `nix develop -c colmena apply --impure --on callisto`
- Verified callisto system is `running`.
- Verified `netbird-combined.service` and `caddy.service` are active.
- Verified `netbird-stun.service` is inactive.
- Verified no local UDP 3478 listener remains.
- Verified `/run/netbird/config.yaml` renders `stun:stun.cloudflare.com:3478`.
- Verified public dashboard, OIDC metadata, and gRPC ingress still work.
- Verified `stunclient stun.cloudflare.com 3478` succeeds.

Linear: MMI-360
