### PR TITLE
feat: enroll ganymede in NetBird

### DIFF
--- a/hosts/ganymede/configuration.nix
+++ b/hosts/ganymede/configuration.nix
@@ -61,6 +61,13 @@ in {
         group = "root";
         mode = "0600";
       };
+      netbirdHomelabHeadlessSetupKey = {
+        reference = "op://Homelab/Netbird Homelab Headless Setup Key/password";
+        path = "/var/lib/opnix/secrets/netbird-homelab-headless-setup-key";
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
     };
 
     systemdIntegration = {
@@ -126,6 +133,32 @@ in {
       enable = true;
       openvpnConfigSecretRef = "op://Homelab/ProtonVPN OpenVPN Ganymede/notesPlain";
       openvpnAuthSecretRef = "op://Homelab/ProtonVPN OpenVPN Ganymede Auth/notesPlain";
+    };
+  };
+
+  services.netbird.package = pkgs.netbird-client;
+  services.netbird.clients.personal = {
+    port = 51820;
+    autoStart = true;
+    openFirewall = true;
+    login = {
+      enable = true;
+      setupKeyFile = "/var/lib/opnix/secrets/netbird-homelab-headless-setup-key";
+      systemdDependencies = ["opnix-secrets.service"];
+    };
+    environment = {
+      NB_ADMIN_URL = "https://netbird.rgbr.ink";
+      NB_MANAGEMENT_URL = "https://netbird.rgbr.ink";
+    };
+    config = {
+      AdminURL = {
+        Scheme = "https";
+        Host = "netbird.rgbr.ink:443";
+      };
+      ManagementURL = {
+        Scheme = "https";
+        Host = "netbird.rgbr.ink:443";
+      };
     };
   };
 

--- a/modules/overlays/default.nix
+++ b/modules/overlays/default.nix
@@ -1,5 +1,6 @@
 [
   (_final: prev: {
+    netbird-client = prev.callPackage ./packages/netbird-client.nix {};
     netbird-server = prev.callPackage ./packages/netbird-server.nix {};
   })
 

--- a/modules/overlays/packages/netbird-client.nix
+++ b/modules/overlays/packages/netbird-client.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+buildGoModule (finalAttrs: {
+  pname = "netbird-client";
+  version = "0.70.4";
+
+  src = fetchFromGitHub {
+    owner = "netbirdio";
+    repo = "netbird";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tfScscRllUlV1V6D66rfT6JEsReDQfVGryVzNebm0vg=";
+  };
+
+  vendorHash = "sha256-IRV1GxdUKgan0GwmBg9acpl7plW01CtEO2FrKrlDdeE=";
+
+  nativeBuildInputs = [installShellFiles];
+
+  subPackages = ["client"];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/netbirdio/netbird/version.version=${finalAttrs.version}"
+    "-X main.builtBy=nix"
+  ];
+
+  # Upstream's Go tests require network access, matching nixpkgs' NetBird packages.
+  doCheck = false;
+
+  postPatch = ''
+    # make it compatible with systemd's RuntimeDirectory
+    substituteInPlace client/cmd/root.go \
+      --replace-fail 'unix:///var/run/netbird.sock' 'unix:///var/run/netbird/sock'
+  '';
+
+  postInstall = ''
+    mv $out/bin/client $out/bin/netbird
+
+    installShellCompletion --cmd netbird \
+      --bash <($out/bin/netbird completion bash) \
+      --fish <($out/bin/netbird completion fish) \
+      --zsh <($out/bin/netbird completion zsh)
+  '';
+
+  meta = {
+    description = "NetBird client";
+    homepage = "https://netbird.io";
+    changelog = "https://github.com/netbirdio/netbird/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      nazarewk
+      saturn745
+      loc
+    ];
+    mainProgram = "netbird";
+  };
+})


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- Package the NetBird client at `v0.70.4` so ganymede runs the same upstream version as the self-hosted server.
- Enroll `ganymede` as the first declarative NixOS NetBird client using an OpNix-backed setup key.
- Configure the client to use `https://netbird.rgbr.ink:443` for management/admin and verify it connects through the self-hosted control plane.

## Verification
- `nix develop -c alejandra --check .`
- `nix develop -c deadnix --fail .`
- `nix flake check --show-trace`
- `nix develop -c colmena apply --impure --on ganymede`
- `netbird-personal version` reports `0.70.4` on ganymede
- `netbird-personal status --detail` shows Management and Signal connected to `https://netbird.rgbr.ink:443`
