### PR TITLE
feat: add personal NetBird client module

### DIFF
--- a/hosts/callisto/configuration.nix
+++ b/hosts/callisto/configuration.nix
@@ -283,6 +283,12 @@ in {
     storeEncryptionKeySecretRef = "op://Homelab/NetBird Store Encryption Key/password";
   };
 
+  services.netbird-personal-client = {
+    enable = true;
+    enableSshServer = true;
+    enableSftp = true;
+  };
+
   services.caddy.virtualHosts."netbird.rgbr.ink" = {
     extraConfig = let
       certPath = config.services.onepassword-secrets.secretPaths.sslCloudflareCert;

--- a/hosts/frame/configuration.nix
+++ b/hosts/frame/configuration.nix
@@ -60,6 +60,11 @@
     };
   };
 
+  services.netbird-personal-client = {
+    enable = true;
+    sshJwtCacheTtl = 600;
+  };
+
   environment.systemPackages = with pkgs; [
     google-chrome
   ];

--- a/hosts/ganymede/configuration.nix
+++ b/hosts/ganymede/configuration.nix
@@ -61,13 +61,6 @@ in {
         group = "root";
         mode = "0600";
       };
-      netbirdHomelabHeadlessSetupKey = {
-        reference = "op://Homelab/Netbird Homelab Headless Setup Key/password";
-        path = "/var/lib/opnix/secrets/netbird-homelab-headless-setup-key";
-        owner = "root";
-        group = "root";
-        mode = "0400";
-      };
     };
 
     systemdIntegration = {
@@ -136,30 +129,10 @@ in {
     };
   };
 
-  services.netbird.package = pkgs.netbird-client;
-  services.netbird.clients.personal = {
-    port = 51820;
-    autoStart = true;
-    openFirewall = true;
-    login = {
-      enable = true;
-      setupKeyFile = "/var/lib/opnix/secrets/netbird-homelab-headless-setup-key";
-      systemdDependencies = ["opnix-secrets.service"];
-    };
-    environment = {
-      NB_ADMIN_URL = "https://netbird.rgbr.ink";
-      NB_MANAGEMENT_URL = "https://netbird.rgbr.ink";
-    };
-    config = {
-      AdminURL = {
-        Scheme = "https";
-        Host = "netbird.rgbr.ink:443";
-      };
-      ManagementURL = {
-        Scheme = "https";
-        Host = "netbird.rgbr.ink:443";
-      };
-    };
+  services.netbird-personal-client = {
+    enable = true;
+    enableSshServer = true;
+    enableSftp = true;
   };
 
   services.portfolio = {

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -31,6 +31,7 @@
     ./locale.nix
     ./networking.nix
     ./netbird-combined.nix
+    ./netbird-personal-client.nix
     ./nvidia.nix
     ./opencode.nix
     ./password-manager.nix

--- a/modules/nixos/netbird-personal-client.nix
+++ b/modules/nixos/netbird-personal-client.nix
@@ -1,0 +1,119 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.netbird-personal-client;
+  setupKeyPath = "/var/lib/opnix/secrets/netbird-homelab-headless-setup-key";
+
+  netbirdUrl = {
+    Scheme = "https";
+    Host = "${cfg.domain}:443";
+  };
+in {
+  options.services.netbird-personal-client = {
+    enable = lib.mkEnableOption "the personal self-hosted NetBird client";
+
+    domain = lib.mkOption {
+      type = lib.types.str;
+      default = "netbird.rgbr.ink";
+      description = "Self-hosted NetBird management and admin domain.";
+    };
+
+    setupKeySecretRef = lib.mkOption {
+      type = lib.types.str;
+      default = "op://Homelab/Netbird Homelab Headless Setup Key/password";
+      description = "1Password reference for the reusable personal NetBird setup key.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 51820;
+      description = "WireGuard port for the personal NetBird client.";
+    };
+
+    enableSshServer = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether this peer should run the NetBird SSH server.";
+    };
+
+    enableSftp = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether NetBird SSH should expose the SFTP subsystem.";
+    };
+
+    enableSshRoot = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether NetBird SSH should allow root login.";
+    };
+
+    enableSshLocalPortForwarding = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether NetBird SSH should allow local port forwarding.";
+    };
+
+    enableSshRemotePortForwarding = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether NetBird SSH should allow remote port forwarding.";
+    };
+
+    disableSshAuth = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether NetBird SSH should disable JWT user authentication.";
+    };
+
+    sshJwtCacheTtl = lib.mkOption {
+      type = lib.types.nullOr lib.types.ints.unsigned;
+      default = null;
+      description = "Optional NetBird SSH JWT cache TTL in seconds for SSH client use.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.onepassword-secrets.secrets.netbirdHomelabHeadlessSetupKey = {
+      reference = cfg.setupKeySecretRef;
+      path = setupKeyPath;
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+
+    services.netbird.package = pkgs.netbird-client;
+    services.netbird.clients.personal = {
+      port = cfg.port;
+      autoStart = true;
+      openFirewall = true;
+      login = {
+        enable = true;
+        setupKeyFile = setupKeyPath;
+        systemdDependencies = ["opnix-secrets.service"];
+      };
+      environment = {
+        NB_ADMIN_URL = "https://${cfg.domain}";
+        NB_DISABLE_SSH_CONFIG = "true";
+        NB_MANAGEMENT_URL = "https://${cfg.domain}";
+      };
+      config =
+        {
+          AdminURL = netbirdUrl;
+          ManagementURL = netbirdUrl;
+          ServerSSHAllowed = cfg.enableSshServer;
+          EnableSSHRoot = cfg.enableSshRoot;
+          EnableSSHSFTP = cfg.enableSftp;
+          EnableSSHLocalPortForwarding = cfg.enableSshLocalPortForwarding;
+          EnableSSHRemotePortForwarding = cfg.enableSshRemotePortForwarding;
+          DisableSSHAuth = cfg.disableSshAuth;
+        }
+        // lib.optionalAttrs (cfg.sshJwtCacheTtl != null) {
+          SSHJWTCacheTTL = cfg.sshJwtCacheTtl;
+        };
+    };
+  };
+}


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- Adds a shared `services.netbird-personal-client` NixOS module for self-hosted personal NetBird enrollment, OpNix setup-key wiring, and SSH-related client flags.
- Migrates `ganymede`, `callisto`, and `frame` to the shared personal client module, enabling NetBird SSH server settings on homelab servers and JWT cache tuning on `frame`.
- Keeps NetBird from imperatively writing OpenSSH config with `NB_DISABLE_SSH_CONFIG=true`.

## Verification
- `nix develop -c alejandra --check .`
- `nix develop -c deadnix --fail .`
- `nix flake check --show-trace`
- Verified `callisto` and `ganymede` NetBird clients are healthy and connected on `0.70.4`.

## Deployment Notes
- `callisto` and `ganymede` have been deployed and verified.
- `frame` was not deployed because SSH host key verification blocked remote access; Ryan will pull this branch on `frame` and deploy locally.
- NetBird SSH still requires dashboard-side management policy; daemons report locally allowed but management-disabled until that policy exists.