### PR TITLE
fix: support interactive NetBird enrollment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,5 +18,6 @@ Start here:
 - `hosts/ganymede.md`
 - `hosts/frame.md`
 - `hosts/macme.md`
+- `capabilities/netbird-overlay.md`
 
 For the full navigation tree, see `SUMMARY.md`.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Ganymede](hosts/ganymede.md)
 - [Macme](hosts/macme.md)
 - [Ingress and DNS](capabilities/ingress-and-dns.md)
+- [NetBird Overlay](capabilities/netbird-overlay.md)
 - [Media and Downloads](capabilities/media-and-downloads.md)
 - [Data Services](capabilities/data-services.md)
 - [Desktop Environment](capabilities/desktop-environment.md)
@@ -18,4 +19,5 @@
 - [UniFi and LAN](external-dependencies/unifi-and-lan.md)
 - [1Password and OpNix](external-dependencies/1password-and-opnix.md)
 - [Frame LUKS and YubiKey](runbooks/frame-luks-yubikey.md)
+- [NetBird Enrollment](runbooks/netbird-enrollment.md)
 - [Remote MCP OAuth](runbooks/remote-mcp-oauth.md)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -62,6 +62,7 @@ The live capability areas in the repo are:
 - user environment
 - deployment and flake outputs
 - AI and OpenCode
+- NetBird overlay networking
 
 Those map more cleanly to the codebase than a module-by-module document set.
 
@@ -73,5 +74,6 @@ These are real properties of the repo today and are worth documenting rather tha
 - Desktop behavior is now cleaner, but still intentionally split between `modules/nixos/session.nix` and `modules/nixos/userland.nix`, with related device support still living in modules like `audio.nix`, `hardware.nix`, and `fingerprint-reader.nix`.
 - `macme` is a shared Darwin base, but the concrete flake outputs are thin wrappers with almost no per-machine differentiation.
 - Some high-level abstractions are intentionally thin. For example, host topology is mostly expressed directly in host configs rather than in a separate service graph.
+- NetBird is declarative on NixOS hosts, but macOS client installation is intentionally manual for now.
 
 Those rough edges are not necessarily bugs, but they are important context for anyone changing the repo.

--- a/docs/architecture/topology.md
+++ b/docs/architecture/topology.md
@@ -47,12 +47,37 @@ Important names include:
 - `dns.lan.rgbr.ink`
 - `ventoy.lan.rgbr.ink`
 
+## Overlay Network
+
+The repo now uses a self-hosted NetBird overlay at `netbird.rgbr.ink`.
+
+`callisto` hosts the NetBird control plane, dashboard, and public Caddy routing for the domain.
+
+Current enrolled or rollout-included peers are:
+
+- `callisto`
+- `ganymede`
+- `frame`
+- `dot`
+- `pip`
+
+NixOS peers use the `personal` NetBird client instance.
+
+Enrollment differs by host type:
+
+- `callisto` and `ganymede` use headless setup-key enrollment
+- `frame` uses interactive SSO/browser enrollment
+- `dot` and `pip` use manually installed macOS clients and manual enrollment
+
+For details, see `docs/capabilities/netbird-overlay.md`.
+
 ## Public Domains
 
 The current public domain surface is:
 
 - `rgbr.ink`
 - `chat.rgbr.ink`
+- `netbird.rgbr.ink`
 - `ryanbr.ink`
 
 `rgbr.ink` currently redirects to `ryanbr.ink` at the Caddy layer.

--- a/docs/capabilities/ingress-and-dns.md
+++ b/docs/capabilities/ingress-and-dns.md
@@ -31,6 +31,7 @@ Current public domains include:
 - `rgbr.ink`
 - `ryanbr.ink`
 - `chat.rgbr.ink`
+- `netbird.rgbr.ink`
 
 Current internal surface includes `*.lan.rgbr.ink`.
 
@@ -65,4 +66,5 @@ In practice, `callisto` uses it to publish the internal service names that point
 ## Current Notes
 
 - `chat.rgbr.ink` is not handled by the generic Caddy abstraction alone; `hosts/callisto/configuration.nix` adds direct `services.caddy.virtualHosts` entries for multi-backend Spacebar routing.
+- `netbird.rgbr.ink` is also handled by a direct Caddy virtual host because NetBird needs gRPC, API, OAuth, relay, WebSocket, well-known, and dashboard routing.
 - Internal DNS names are currently declared directly in the host config rather than generated from a separate inventory file.

--- a/docs/capabilities/netbird-overlay.md
+++ b/docs/capabilities/netbird-overlay.md
@@ -1,0 +1,163 @@
+# NetBird Overlay
+
+NetBird is the private overlay network for the homelab and operator endpoints.
+
+## Purpose
+
+The NetBird overlay provides:
+
+- authenticated private peer access across enrolled machines
+- a self-hosted management, signal, relay, and dashboard endpoint
+- a path for operator devices to reach the homelab without depending only on LAN presence
+- optional NetBird SSH and SFTP support for selected server peers
+
+The LAN and ingress stack still matter. NetBird adds an overlay network; it does not replace the UniFi LAN, Blocky DNS, Caddy ingress, or Colmena target addressing.
+
+## Current Rollout State
+
+| Host | Role | NetBird status | Enrollment | Install source |
+| --- | --- | --- | --- | --- |
+| `callisto` | control plane, ingress, server peer | enrolled | setup key | declarative NixOS |
+| `ganymede` | backend workload peer | enrolled | setup key | declarative NixOS |
+| `frame` | Linux workstation peer | enrolled | interactive | declarative NixOS client, manual SSO |
+| `dot` | macOS operator endpoint | enrolled | interactive/manual | manually installed macOS app |
+| `pip` | macOS operator endpoint | enrolled for rollout purposes | interactive/manual | manually installed macOS app |
+
+The macOS clients are intentionally not managed by nix-darwin right now. Install and enroll the upstream NetBird macOS app manually on those machines.
+
+## Server Placement
+
+`callisto` hosts the self-hosted NetBird control plane through `services.netbird-combined`.
+
+The server module is `modules/nixos/netbird-combined.nix`.
+
+The public NetBird domain is:
+
+- `netbird.rgbr.ink`
+
+The public management, signal, relay, dashboard, and admin surface is reached through:
+
+- `https://netbird.rgbr.ink:443`
+
+`callisto` uses a direct Caddy virtual host for `netbird.rgbr.ink` because NetBird needs more than a simple reverse proxy. The route handles gRPC, API, OAuth, relay, WebSocket proxy paths, well-known paths, and the dashboard.
+
+## Client Placement
+
+NixOS hosts use the `services.netbird-personal-client` module from `modules/nixos/netbird-personal-client.nix`.
+
+The declarative client instance is named `personal`.
+
+Important client paths and names:
+
+- CLI: `netbird-personal`
+- service: `netbird-personal.service`
+- setup-key login service for headless hosts: `netbird-personal-login.service`
+- runtime socket: `/run/netbird-personal/sock`
+- state directory: `/var/lib/netbird-personal`
+- config file: `/var/lib/netbird-personal/config.json`
+- WireGuard interface: `nb-personal`
+
+The generic `netbird` CLI is not expected to exist for the NixOS instance. Use `netbird-personal`.
+
+## Enrollment Modes
+
+`services.netbird-personal-client.enrollment` controls how a NixOS peer enrolls.
+
+### Setup-Key Enrollment
+
+`setup-key` is the default mode.
+
+Use it for headless or server hosts.
+
+Behavior:
+
+- creates the OpNix-managed reusable headless setup key secret
+- enables `netbird-personal-login.service`
+- enrolls the peer without browser interaction
+- keeps headless server enrollment declarative
+
+Current setup-key hosts:
+
+- `callisto`
+- `ganymede`
+
+### Interactive Enrollment
+
+`interactive` is for laptops and desktops where a human should complete SSO or browser-based login.
+
+Behavior:
+
+- does not create the headless setup-key secret
+- disables and masks `netbird-personal-login.service`
+- keeps `netbird-personal.service` running
+- requires manual enrollment with the instance CLI
+
+Current interactive NixOS host:
+
+- `frame`
+
+Interactive enrollment command:
+
+```sh
+sudo netbird-personal up --no-browser
+```
+
+## Secrets
+
+NetBird secrets are delivered by 1Password and OpNix.
+
+Server secrets on `callisto`:
+
+- `/var/lib/opnix/secrets/netbird-auth-secret`
+- `/var/lib/opnix/secrets/netbird-store-encryption-key`
+
+Reusable headless setup-key secret for setup-key clients:
+
+- `/var/lib/opnix/secrets/netbird-homelab-headless-setup-key`
+
+Do not print setup keys, tokens, NetBird private keys, or secret file contents during triage.
+
+## External Dependencies
+
+NetBird depends on:
+
+- Cloudflare DNS for `netbird.rgbr.ink`
+- Caddy on `callisto` for public TLS and routing
+- 1Password and OpNix for server secrets and headless setup-key material
+- working DNS during activation and enrollment
+- upstream STUN, currently Cloudflare public STUN by module default
+
+## Operational Checks
+
+Useful read-only checks on NixOS clients:
+
+```sh
+netbird-personal version
+sudo netbird-personal status --detail
+systemctl status netbird-personal.service netbird-personal-login.service --no-pager || true
+systemctl is-enabled netbird-personal-login.service || true
+```
+
+Expected behavior differs by enrollment mode:
+
+- setup-key hosts should have `netbird-personal-login.service` enabled
+- `frame` should have `netbird-personal-login.service` masked or disabled
+- enrolled peers should appear in the NetBird dashboard
+
+## Known Failure Modes
+
+If `opnix-secrets.service` fails during activation, setup-key enrollment can fail because the login service depends on the setup-key credential.
+
+If DNS is unavailable during activation, OpNix may fail to reach 1Password and NetBird may fail to resolve `netbird.rgbr.ink`.
+
+If a client reports `NeedsLogin` or `SessionExpired`, the daemon is present but enrollment or session state is incomplete.
+
+If a normal user runs `netbird-personal status`, socket permissions may prevent access. Use `sudo netbird-personal status --detail` for the system-managed instance.
+
+## Future Work
+
+Possible follow-up work:
+
+- decide whether macOS NetBird should remain manually managed or become declarative later
+- document stable NetBird peer names and tags once access policies mature
+- add policy and ACL documentation after the peer model settles

--- a/docs/external-dependencies/1password-and-opnix.md
+++ b/docs/external-dependencies/1password-and-opnix.md
@@ -10,6 +10,7 @@
 - application secrets for hosted services
 - Kagi API key delivery
 - OpenCode instance identity material
+- NetBird server secrets and headless setup-key material
 
 ## Where They Appear In Code
 
@@ -17,6 +18,8 @@
 - `modules/nixos/opencode.nix`
 - `modules/nixos/clickhouse.nix`
 - `modules/nixos/torrents.nix`
+- `modules/nixos/netbird-combined.nix`
+- `modules/nixos/netbird-personal-client.nix`
 - `modules/nixos/security.nix`
 - shared config deployment under `modules/common/users/config-files/`
 
@@ -31,6 +34,8 @@ If OpNix or 1Password delivery is broken, the impact can include:
 - torrent VPN configuration failing to materialize
 - ClickHouse admin bootstrap failing
 - security features such as U2F configuration missing expected files
+- NetBird server startup failing because auth or store-encryption secrets are missing
+- headless NetBird client enrollment failing because setup-key material is missing
 
 ## Current Pattern
 
@@ -39,3 +44,11 @@ The repo generally treats secrets as:
 - referenced declaratively in code
 - materialized onto the machine at known paths
 - consumed by services or copied into user config where needed
+
+NetBird uses this pattern for:
+
+- `/var/lib/opnix/secrets/netbird-auth-secret`
+- `/var/lib/opnix/secrets/netbird-store-encryption-key`
+- `/var/lib/opnix/secrets/netbird-homelab-headless-setup-key`
+
+Interactive clients such as `frame` should not depend on the reusable headless setup key.

--- a/docs/external-dependencies/cloudflare.md
+++ b/docs/external-dependencies/cloudflare.md
@@ -8,6 +8,7 @@ Cloudflare is a first-class external dependency for the ingress stack.
 - DNS-01 validation for internal ACME certificates
 - origin certificate material used by Caddy
 - API token access for DNS automation
+- public DNS and TLS routing for the self-hosted NetBird endpoint
 
 ## Where It Appears In Code
 
@@ -22,6 +23,7 @@ Cloudflare currently supports:
 - `rgbr.ink`
 - `ryanbr.ink`
 - `lan.rgbr.ink` certificate issuance flows
+- `netbird.rgbr.ink`
 
 ## Operational Importance
 
@@ -30,3 +32,4 @@ If Cloudflare DNS or token delivery is broken:
 - public ingress can degrade
 - internal ACME certificate issuance can fail
 - Caddy reloads that depend on certificate material can fail
+- NetBird dashboard, management, signal, and relay access can degrade

--- a/docs/external-dependencies/unifi-and-lan.md
+++ b/docs/external-dependencies/unifi-and-lan.md
@@ -7,6 +7,7 @@ The repo assumes a specific LAN environment.
 - stable private addressing for the Colmena targets
 - a local DNS resolver expectation in shared networking config
 - workstation and server connectivity inside the homelab
+- the base network underneath the NetBird overlay
 
 ## Where It Appears In Code
 
@@ -19,6 +20,7 @@ The repo assumes a specific LAN environment.
 - the homelab LAN lives on `192.168.11.0/24`
 - `192.168.11.1` is the default resolver that the repo expects
 - `callisto`, `ganymede`, and `frame` have stable private addresses used directly by deployment and proxy config
+- NetBird does not replace these LAN assumptions yet
 
 ## Operational Importance
 
@@ -28,3 +30,4 @@ If the LAN addressing or upstream resolver changes, the repo will need updates i
 - reverse-proxy target definitions
 - internal DNS mappings
 - base networking defaults
+- NetBird activation and enrollment workflows that depend on working DNS

--- a/docs/hosts/callisto.md
+++ b/docs/hosts/callisto.md
@@ -20,6 +20,8 @@
 - Caddy via `services.web.caddy`
 - Blocky via `services.dns.blocky`
 - Ventoy Web via `services.tools."ventoy-web"`
+- NetBird combined server and dashboard via `services.netbird-combined`
+- NetBird personal client with setup-key enrollment
 - OpNix-managed TLS material and Cloudflare token files
 
 ## What It Proxies
@@ -46,6 +48,15 @@ That includes:
 - `ryanbr.ink`
 - `chat.rgbr.ink`
 - `*.lan.rgbr.ink`
+- `netbird.rgbr.ink`
+
+## NetBird
+
+`callisto` is both the NetBird control-plane host and a NetBird peer.
+
+The control plane is exposed at `netbird.rgbr.ink` through a direct Caddy virtual host. That route handles dashboard traffic plus NetBird API, OAuth, relay, WebSocket, and gRPC paths.
+
+The local peer uses setup-key enrollment and has NetBird SSH/SFTP enabled.
 
 ## Spacebar Routing
 
@@ -69,3 +80,5 @@ It is intentionally not the main application box. That split keeps edge responsi
 - `modules/nixos/caddy.nix`
 - `modules/nixos/blocky.nix`
 - `modules/nixos/ventoy-web.nix`
+- `modules/nixos/netbird-combined.nix`
+- `modules/nixos/netbird-personal-client.nix`

--- a/docs/hosts/frame.md
+++ b/docs/hosts/frame.md
@@ -22,6 +22,7 @@
 - pulls a Kagi API key through OpNix
 - declares a NetworkManager Wi-Fi profile for the home network
 - overrides the shared Hyprland monitor config with `hosts/frame/hypr/monitors.conf`
+- runs the `personal` NetBird client with interactive enrollment
 
 ## Storage and Install Model
 
@@ -59,11 +60,26 @@ It exists to:
 - act as an endpoint into the homelab
 - perform edits, local rebuilds, and deployments
 
+## NetBird
+
+`frame` is an interactive NetBird peer.
+
+It uses `services.netbird-personal-client.enrollment = "interactive"`, so it should not consume the reusable headless setup key.
+
+Expected behavior:
+
+- `netbird-personal.service` runs the client daemon
+- `netbird-personal-login.service` is masked or disabled
+- enrollment is completed with `sudo netbird-personal up --no-browser`
+
+For enrollment and recovery steps, see `docs/runbooks/netbird-enrollment.md`.
+
 ## Main Code Paths
 
 - `hosts/frame/configuration.nix`
 - `hosts/frame/disko.nix`
 - `hosts/frame/hypr/monitors.conf`
 - `modules/nixos/default.nix`
+- `modules/nixos/netbird-personal-client.nix`
 - `modules/common/`
 - `docs/runbooks/frame-luks-yubikey.md`

--- a/docs/hosts/ganymede.md
+++ b/docs/hosts/ganymede.md
@@ -43,6 +43,7 @@
 - ClickHouse
 - PostgreSQL
 - Spacebar
+- NetBird personal client with setup-key enrollment
 
 ## Data Responsibilities
 
@@ -64,6 +65,14 @@ Instead:
 - `callisto` terminates and routes public or LAN traffic
 - `ganymede` serves the backend applications behind that ingress layer
 
+`ganymede` is also a NetBird peer for private overlay access. Browser-facing services still primarily flow through `callisto` rather than direct peer access.
+
+## NetBird
+
+`ganymede` uses the `personal` NetBird client instance with setup-key enrollment.
+
+NetBird SSH and SFTP are enabled for this peer.
+
 ## GPU Role
 
 `ganymede` enables the NVIDIA module and is the only host in the repo currently configured with NVIDIA support.
@@ -80,3 +89,4 @@ Instead:
 - `modules/nixos/opencode.nix`
 - `modules/nixos/clickhouse.nix`
 - `modules/nixos/postgres.nix`
+- `modules/nixos/netbird-personal-client.nix`

--- a/docs/hosts/macme.md
+++ b/docs/hosts/macme.md
@@ -23,6 +23,7 @@ Both currently build from the same shared `hosts/macme/configuration.nix` base a
 
 - OpNix on Darwin
 - WireGuard config material under `/etc/wireguard`
+- manually installed NetBird client on enrolled macOS endpoints
 - Kagi API key material
 - nix-darwin system settings
 - Homebrew enablement through `nix-homebrew`
@@ -43,6 +44,16 @@ They exist to:
 - access the homelab
 - run the shared user environment
 - perform development and administration tasks
+
+## NetBird
+
+`dot` is enrolled in the self-hosted NetBird network.
+
+`pip` is also considered part of the NetBird rollout and should be enrolled manually when next used.
+
+The macOS NetBird client is intentionally installed manually rather than through nix-darwin. Use the upstream macOS app and enroll through the UI against `https://netbird.rgbr.ink`.
+
+Do not infer that NetBird client state is managed by this repository on macOS. The repo documents the expectation, but the app install and enrollment are operator-managed.
 
 ## Main Code Paths
 

--- a/docs/runbooks/netbird-enrollment.md
+++ b/docs/runbooks/netbird-enrollment.md
@@ -1,0 +1,136 @@
+# NetBird Enrollment
+
+This runbook covers enrolling and checking peers in the self-hosted NetBird network at `netbird.rgbr.ink`.
+
+## Safety Rules
+
+- Do not print setup keys, tokens, NetBird private keys, or files under `/var/lib/opnix/secrets/`.
+- Do not use the headless setup key for interactive laptops or desktops.
+- Do not start `netbird-personal-login.service` on `frame`.
+- Use `sudo` for the NixOS system-managed client instance because its socket and state are service-owned.
+
+## NixOS Client Checks
+
+Run these on a NixOS peer:
+
+```sh
+netbird-personal version
+sudo netbird-personal status --detail
+systemctl is-enabled netbird-personal-login.service || true
+systemctl status netbird-personal.service netbird-personal-login.service --no-pager || true
+```
+
+Useful service logs:
+
+```sh
+sudo journalctl -u netbird-personal.service -n 200 --no-pager
+sudo journalctl -u netbird-personal-login.service -n 160 --no-pager
+sudo journalctl -u opnix-secrets.service -n 100 --no-pager
+```
+
+Redact setup keys, tokens, secrets, passwords, and private keys before sharing logs.
+
+## Headless NixOS Enrollment
+
+Headless hosts use `services.netbird-personal-client.enrollment = "setup-key"`.
+
+This is the default mode.
+
+Current setup-key hosts:
+
+- `callisto`
+- `ganymede`
+
+Expected service behavior:
+
+- `netbird-personal.service` is enabled and running
+- `netbird-personal-login.service` is enabled
+- the setup-key credential is loaded by systemd from OpNix material
+
+Do not manually print or pass the setup key in a shell command.
+
+If setup-key enrollment failed during activation, first check:
+
+```sh
+systemctl status opnix-secrets.service netbird-personal.service netbird-personal-login.service --no-pager || true
+sudo netbird-personal status --detail
+```
+
+Common causes:
+
+- OpNix failed before the setup-key file was available
+- DNS failed during activation
+- `netbird.rgbr.ink` could not resolve during client startup
+
+## Interactive NixOS Enrollment
+
+Interactive NixOS hosts use `services.netbird-personal-client.enrollment = "interactive"`.
+
+Current interactive NixOS host:
+
+- `frame`
+
+Expected service behavior on `frame`:
+
+- `netbird-personal.service` is enabled and running
+- `netbird-personal-login.service` is masked or disabled
+- no headless setup-key secret is declared for the host
+
+Enroll interactively:
+
+```sh
+sudo netbird-personal up --no-browser
+```
+
+Copy the printed URL into a normal browser and complete login through the NetBird UI.
+
+Verify after login:
+
+```sh
+sudo netbird-personal status --detail
+```
+
+The peer should also appear in the NetBird dashboard.
+
+## Recover From Accidental Setup-Key Enrollment
+
+If an interactive host such as `frame` was accidentally enrolled with the headless setup key:
+
+1. Deploy config with `enrollment = "interactive"`.
+2. Confirm `netbird-personal-login.service` is masked or disabled.
+3. Deregister or remove the accidental peer registration.
+4. Re-enroll with `sudo netbird-personal up --no-browser`.
+5. Remove duplicate or stale peers from the NetBird dashboard if needed.
+
+Deregister command when local cleanup is desired:
+
+```sh
+sudo netbird-personal deregister
+```
+
+## macOS Manual Clients
+
+macOS NetBird clients are currently managed manually, not through nix-darwin.
+
+Current macOS rollout state:
+
+- `dot` is enrolled
+- `pip` is considered enrolled for rollout purposes and should be enrolled manually when next used
+
+Install the upstream NetBird macOS app manually, then use the app login flow against:
+
+- `https://netbird.rgbr.ink`
+
+After enrollment, verify the peer appears in the NetBird dashboard with the expected hostname.
+
+Do not add the macOS NetBird client to the nix-darwin config unless the repository intentionally changes to declarative macOS client management later.
+
+## Status Meanings
+
+`Connected` means the peer is enrolled and connected.
+
+`NeedsLogin` means the daemon exists but has not completed enrollment.
+
+`SessionExpired` means the peer needs an interactive login refresh or re-enrollment.
+
+Permission errors against `/run/netbird-personal/sock` usually mean the command was run as a normal user against the system-managed instance. Use `sudo`.

--- a/hosts/frame/configuration.nix
+++ b/hosts/frame/configuration.nix
@@ -62,6 +62,7 @@
 
   services.netbird-personal-client = {
     enable = true;
+    enrollment = "interactive";
     sshJwtCacheTtl = 600;
   };
 

--- a/modules/nixos/netbird-personal-client.nix
+++ b/modules/nixos/netbird-personal-client.nix
@@ -6,6 +6,7 @@
 }: let
   cfg = config.services.netbird-personal-client;
   setupKeyPath = "/var/lib/opnix/secrets/netbird-homelab-headless-setup-key";
+  usesSetupKey = cfg.enrollment == "setup-key";
 
   netbirdUrl = {
     Scheme = "https";
@@ -25,6 +26,15 @@ in {
       type = lib.types.str;
       default = "op://Homelab/Netbird Homelab Headless Setup Key/password";
       description = "1Password reference for the reusable personal NetBird setup key.";
+    };
+
+    enrollment = lib.mkOption {
+      type = lib.types.enum ["setup-key" "interactive"];
+      default = "setup-key";
+      description = ''
+        Enrollment flow for the client. Use setup-key for headless hosts and
+        interactive for laptops or desktops that should authenticate through SSO.
+      '';
     };
 
     port = lib.mkOption {
@@ -77,12 +87,14 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    services.onepassword-secrets.secrets.netbirdHomelabHeadlessSetupKey = {
-      reference = cfg.setupKeySecretRef;
-      path = setupKeyPath;
-      owner = "root";
-      group = "root";
-      mode = "0400";
+    services.onepassword-secrets.secrets = lib.optionalAttrs usesSetupKey {
+      netbirdHomelabHeadlessSetupKey = {
+        reference = cfg.setupKeySecretRef;
+        path = setupKeyPath;
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
     };
 
     services.netbird.package = pkgs.netbird-client;
@@ -90,7 +102,7 @@ in {
       port = cfg.port;
       autoStart = true;
       openFirewall = true;
-      login = {
+      login = lib.optionalAttrs usesSetupKey {
         enable = true;
         setupKeyFile = setupKeyPath;
         systemdDependencies = ["opnix-secrets.service"];
@@ -114,6 +126,10 @@ in {
         // lib.optionalAttrs (cfg.sshJwtCacheTtl != null) {
           SSHJWTCacheTTL = cfg.sshJwtCacheTtl;
         };
+    };
+
+    systemd.services.netbird-personal-login = lib.mkIf (!usesSetupKey) {
+      enable = false;
     };
   };
 }


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- Add an explicit NetBird enrollment mode so headless hosts keep setup-key enrollment while frame uses interactive SSO.
- Document the self-hosted NetBird rollout, enrollment flows, host roles, external dependencies, and macOS manual client expectations.

## Validation
- nix flake check --show-trace
- git diff --check